### PR TITLE
fix: require sequential approval gates between spec, plan, and tasks

### DIFF
--- a/.opencode/command/sdd.md
+++ b/.opencode/command/sdd.md
@@ -1,9 +1,9 @@
 ---
-description: Unified SDD workflow entrypoint — guides users through specification, clarification, planning, and automatic task preparation from a single OpenCode command. Handles repository initialization, new feature planning, and resume-from-state scenarios. Tasks are generated automatically once planning artifacts are complete.
+description: Unified SDD workflow entrypoint — guides users through specification, clarification, planning, and automatic task preparation from a single OpenCode command. Handles repository initialization, new feature planning, and resume-from-state scenarios. Each planning stage requires explicit user approval before the next stage is unlocked.
 handoffs:
   - label: Run Task Generation
     agent: speckit.tasks
-    prompt: Generate task breakdown for the current feature workspace. Context: feature planning is complete and tasks.md needs to be produced. Only invoke this after confirming that spec.md, plan.md, research.md, data-model.md, and quickstart.md are all present and complete.
+    prompt: Generate task breakdown for the current feature workspace. Context: feature planning is complete and tasks.md needs to be produced. Only invoke this after confirming that spec.md, plan.md, research.md, data-model.md, and quickstart.md are all present and complete and the user has explicitly approved the planning package.
 ---
 
 ## User Input
@@ -123,23 +123,33 @@ When the user provides a new feature request:
 
 2. **Run `.specify/scripts/bash/create-new-feature.sh`** with the confirmed prefix and short name to create the feature workspace
 
-3. **Guided specify**: Create or update `spec.md` in the feature workspace:
-   - Extract actors, actions, data, and constraints from the feature request
-   - Generate user stories with clear acceptance scenarios
-   - Identify edge cases and success criteria
-   - When ambiguous: ask focused clarification questions sequentially, recommend answers, record accepted responses
+   3. **Guided specify**: Create or update `spec.md` in the feature workspace:
+    - Extract actors, actions, data, and constraints from the feature request
+    - Generate user stories with clear acceptance scenarios
+    - Identify edge cases and success criteria
+    - When ambiguous: ask focused clarification questions sequentially, recommend answers, record accepted responses
 
-4. **Guided plan**: After spec is approved:
-   - Run `.specify/scripts/bash/setup-plan.sh --json` to prepare the planning package
-   - Generate `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and any relevant markdown contracts inside the feature workspace
-   - Fill Technical Context, Constitution Check, Project Structure, and Complexity Tracking
+   4. **Guided spec approval**: After spec is generated, stop and ask the user to review and approve `spec.md`:
+    - The workflow waits for explicit user approval before generating any planning artifacts
+    - If the user requests changes, update `spec.md` and wait for re-approval
+    - Only after approval, proceed to the planning stage
 
-5. **Guided task preparation**: After planning is complete:
-   - Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` to verify readiness
-   - The workflow automatically generates `tasks.md` using the planning artifacts once they are complete
-   - Do NOT ask the user to run a separate task-generation command
+   5. **Guided plan**: After spec is approved:
+    - Run `.specify/scripts/bash/setup-plan.sh --json` to prepare the planning package
+    - Generate `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and any relevant markdown contracts inside the feature workspace
+    - Fill Technical Context, Constitution Check, Project Structure, and Complexity Tracking
 
-6. **Present next step**: Always end with a clear, specific recommendation for what to do next
+   6. **Guided plan approval**: After planning package is generated, stop and ask the user to review and approve the plan:
+    - The workflow waits for explicit user approval before generating `tasks.md`
+    - If the user requests changes, update the planning artifacts and wait for re-approval
+    - Only after approval, proceed to task generation
+
+   7. **Guided task preparation**: After plan is approved:
+    - Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` to verify readiness
+    - Generate `tasks.md` using the approved planning artifacts as input
+    - Do NOT ask the user to run a separate task-generation command
+
+   8. **Present next step**: Always end with a clear, specific recommendation for what to do next
 
 ### Step 5: Resume Flow
 
@@ -147,12 +157,14 @@ When the user returns to a feature workspace that already has partial artifacts:
 
 1. **Detect active workspace**: Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` to find the current feature workspace
 2. **Evaluate artifact state**: Check which artifacts exist and are current:
-   - `spec.md` only → recommend starting planning
-   - `spec.md` + `plan.md` → automatically generate tasks (no manual command needed)
+   - `spec.md` exists but approval state is unknown → recommend reviewing and approving spec
+   - `spec.md` approved but `plan.md` missing → generate planning package
+   - Planning package exists but approval state is unknown → recommend reviewing and approving plan
+   - Planning package approved but `tasks.md` missing → generate tasks
    - Partial artifacts → recommend resuming from the missing/outdated one
-3. **Resume from correct phase**: Do not recreate existing valid artifacts
-4. **Report state**: Clearly show what exists, what is missing, and what will be produced next
-5. **Present next step**: Recommend the specific next action
+3. **Resume from correct phase**: Do not recreate existing valid artifacts; respect approval gates
+4. **Report state**: Clearly show what exists, what is missing, what is waiting for approval, and what will be produced next
+5. **Present next step**: Recommend the specific next action, including any pending approval
 
 ### Key Behavioral Rules
 
@@ -162,13 +174,16 @@ When the user returns to a feature workspace that already has partial artifacts:
 - **Markdown-only outputs**: All artifacts created by this workflow are markdown files in the feature workspace.
 - **Managed init backend**: If non-markdown workflow assets must be installed, do that through the managed repository-init backend rather than by agent-authored code generation.
 - **Sequential clarification**: Ask one question at a time. Recommend the best answer. Record accepted answers in the relevant artifact.
+- **Sequential approval gates**: The workflow generates one stage at a time and waits for explicit user approval before advancing. Approval gates are: spec approval before planning, and plan approval before tasks.
 - **No destructive operations**: Never overwrite existing user-managed files without explicit user consent.
 - **Traceability**: Every artifact update must preserve the link back to the original feature request and any clarification answers.
 - **Non-interactive detection**: When `sdd` is invoked with explicit arguments, use those directly without prompting for missing information.
-- **Automatic task generation**: After `spec.md`, `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` are complete, the workflow automatically generates `tasks.md` without requiring the user to run a separate command.
+- **Conservative resume**: When resuming without known approval state, the workflow asks for revalidation rather than auto-advancing.
 
 ### After SDD workflow completes
 
 Check for extension hooks under `hooks.after_sdd` in `.specify/extensions.yml` (if present) and execute any mandatory hooks before returning control to the user.
 
-Context for SDD workflow: $ARGUMENTS
+Context for SDD workflow: Each stage requires user approval before the next stage is generated. Spec approval gates planning. Plan approval gates task generation.
+
+$ARGUMENTS

--- a/.opencode/managed-assets/.opencode/command/sdd.md
+++ b/.opencode/managed-assets/.opencode/command/sdd.md
@@ -1,9 +1,9 @@
 ---
-description: Unified SDD workflow entrypoint — guides users through specification, clarification, planning, and automatic task preparation from a single OpenCode command. Handles repository initialization, new feature planning, and resume-from-state scenarios. Tasks are generated automatically once planning artifacts are complete.
+description: Unified SDD workflow entrypoint — guides users through specification, clarification, planning, and automatic task preparation from a single OpenCode command. Handles repository initialization, new feature planning, and resume-from-state scenarios. Each planning stage requires explicit user approval before the next stage is unlocked.
 handoffs:
   - label: Run Task Generation
-    agent: speckit.tasks
-    prompt: Generate task breakdown for the current feature workspace. Context: feature planning is complete and tasks.md needs to be produced. Only invoke this after confirming that spec.md, plan.md, research.md, data-model.md, and quickstart.md are all present and complete.
+    agent: specket.tasks
+    prompt: Generate task breakdown for the current feature workspace. Context: feature planning is complete and tasks.md needs to be produced. Only invoke this after confirming that spec.md, plan.md, research.md, data-model.md, and quickstart.md are all present and complete and the user has explicitly approved the planning package.
 ---
 
 ## User Input
@@ -123,23 +123,33 @@ When the user provides a new feature request:
 
 2. **Run `.specify/scripts/bash/create-new-feature.sh`** with the confirmed prefix and short name to create the feature workspace
 
-3. **Guided specify**: Create or update `spec.md` in the feature workspace:
-   - Extract actors, actions, data, and constraints from the feature request
-   - Generate user stories with clear acceptance scenarios
-   - Identify edge cases and success criteria
-   - When ambiguous: ask focused clarification questions sequentially, recommend answers, record accepted responses
+   3. **Guided specify**: Create or update `spec.md` in the feature workspace:
+    - Extract actors, actions, data, and constraints from the feature request
+    - Generate user stories with clear acceptance scenarios
+    - Identify edge cases and success criteria
+    - When ambiguous: ask focused clarification questions sequentially, recommend answers, record accepted responses
 
-4. **Guided plan**: After spec is approved:
-   - Run `.specify/scripts/bash/setup-plan.sh --json` to prepare the planning package
-   - Generate `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and any relevant markdown contracts inside the feature workspace
-   - Fill Technical Context, Constitution Check, Project Structure, and Complexity Tracking
+   4. **Guided spec approval**: After spec is generated, stop and ask the user to review and approve `spec.md`:
+    - The workflow waits for explicit user approval before generating any planning artifacts
+    - If the user requests changes, update `spec.md` and wait for re-approval
+    - Only after approval, proceed to the planning stage
 
-5. **Guided task preparation**: After planning is complete:
-   - Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` to verify readiness
-   - The workflow automatically generates `tasks.md` using the planning artifacts once they are complete
-   - Do NOT ask the user to run a separate task-generation command
+   5. **Guided plan**: After spec is approved:
+    - Run `.specify/scripts/bash/setup-plan.sh --json` to prepare the planning package
+    - Generate `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, and any relevant markdown contracts inside the feature workspace
+    - Fill Technical Context, Constitution Check, Project Structure, and Complexity Tracking
 
-6. **Present next step**: Always end with a clear, specific recommendation for what to do next
+   6. **Guided plan approval**: After planning package is generated, stop and ask the user to review and approve the plan:
+    - The workflow waits for explicit user approval before generating `tasks.md`
+    - If the user requests changes, update the planning artifacts and wait for re-approval
+    - Only after approval, proceed to task generation
+
+   7. **Guided task preparation**: After plan is approved:
+    - Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` to verify readiness
+    - Generate `tasks.md` using the approved planning artifacts as input
+    - Do NOT ask the user to run a separate task-generation command
+
+   8. **Present next step**: Always end with a clear, specific recommendation for what to do next
 
 ### Step 5: Resume Flow
 
@@ -147,12 +157,14 @@ When the user returns to a feature workspace that already has partial artifacts:
 
 1. **Detect active workspace**: Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` to find the current feature workspace
 2. **Evaluate artifact state**: Check which artifacts exist and are current:
-   - `spec.md` only → recommend starting planning
-   - `spec.md` + `plan.md` → automatically generate tasks (no manual command needed)
+   - `spec.md` exists but approval state is unknown → recommend reviewing and approving spec
+   - `spec.md` approved but `plan.md` missing → generate planning package
+   - Planning package exists but approval state is unknown → recommend reviewing and approving plan
+   - Planning package approved but `tasks.md` missing → generate tasks
    - Partial artifacts → recommend resuming from the missing/outdated one
-3. **Resume from correct phase**: Do not recreate existing valid artifacts
-4. **Report state**: Clearly show what exists, what is missing, and what will be produced next
-5. **Present next step**: Recommend the specific next action
+3. **Resume from correct phase**: Do not recreate existing valid artifacts; respect approval gates
+4. **Report state**: Clearly show what exists, what is missing, what is waiting for approval, and what will be produced next
+5. **Present next step**: Recommend the specific next action, including any pending approval
 
 ### Key Behavioral Rules
 
@@ -162,13 +174,17 @@ When the user returns to a feature workspace that already has partial artifacts:
 - **Markdown-only outputs**: All artifacts created by this workflow are markdown files in the feature workspace.
 - **Managed init backend**: If non-markdown workflow assets must be installed, do that through the managed repository-init backend rather than by agent-authored code generation.
 - **Sequential clarification**: Ask one question at a time. Recommend the best answer. Record accepted answers in the relevant artifact.
+- **Sequential approval gates**: The workflow generates one stage at a time and waits for explicit user approval before advancing. Approval gates are: spec approval before planning, and plan approval before tasks.
 - **No destructive operations**: Never overwrite existing user-managed files without explicit user consent.
 - **Traceability**: Every artifact update must preserve the link back to the original feature request and any clarification answers.
 - **Non-interactive detection**: When `sdd` is invoked with explicit arguments, use those directly without prompting for missing information.
 - **Automatic task generation**: After `spec.md`, `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` are complete, the workflow automatically generates `tasks.md` without requiring the user to run a separate command.
+- **Conservative resume**: When resuming without known approval state, the workflow asks for revalidation rather than auto-advancing.
 
 ### After SDD workflow completes
 
 Check for extension hooks under `hooks.after_sdd` in `.specify/extensions.yml` (if present) and execute any mandatory hooks before returning control to the user.
 
-Context for SDD workflow: $ARGUMENTS
+Context for SDD workflow: Each stage requires user approval before the next stage is generated. Spec approval gates planning. Plan approval gates task generation.
+
+$ARGUMENTS

--- a/.opencode/src/workflow/evaluate-artifact-state.ts
+++ b/.opencode/src/workflow/evaluate-artifact-state.ts
@@ -6,6 +6,8 @@ interface EvaluateArtifactStateInput {
   specExists: boolean;
   planExists: boolean;
   tasksExists: boolean;
+  specApproved: boolean;
+  planApproved: boolean;
   hasOutstandingClarifications?: boolean;
   hasResumeIntent?: boolean;
 }
@@ -21,6 +23,8 @@ function evaluateArtifactState(input: EvaluateArtifactStateInput): ArtifactState
     specExists: input.specExists,
     planExists: input.planExists,
     tasksExists: input.tasksExists,
+    specApproved: input.specApproved,
+    planApproved: input.planApproved,
     hasOutstandingClarifications: input.hasOutstandingClarifications ?? false,
     hasResumeIntent: input.hasResumeIntent ?? false,
   });

--- a/.opencode/src/workflow/phase-router.ts
+++ b/.opencode/src/workflow/phase-router.ts
@@ -13,8 +13,16 @@ function determineNextPhase(input: WorkflowRouteInput): WorkflowPhase {
     return WORKFLOW_PHASE.CLARIFY;
   }
 
+  if (input.specExists && !input.specApproved) {
+    return WORKFLOW_PHASE.WAITING_SPEC_APPROVAL;
+  }
+
   if (!input.planExists) {
     return WORKFLOW_PHASE.PLAN;
+  }
+
+  if (input.planExists && !input.planApproved) {
+    return WORKFLOW_PHASE.WAITING_PLAN_APPROVAL;
   }
 
   if (!input.tasksExists) {
@@ -30,10 +38,14 @@ function getNextRecommendation(phase: WorkflowPhase): string {
       return "Run the repository initialization flow before starting feature planning.";
     case WORKFLOW_PHASE.SPECIFY:
       return "Create or update spec.md for the active feature request.";
+    case WORKFLOW_PHASE.WAITING_SPEC_APPROVAL:
+      return "Review and approve spec.md to unlock the planning stage.";
     case WORKFLOW_PHASE.CLARIFY:
       return "Resolve the remaining high-impact clarification questions before planning.";
     case WORKFLOW_PHASE.PLAN:
       return "Generate the planning package for the active feature workspace.";
+    case WORKFLOW_PHASE.WAITING_PLAN_APPROVAL:
+      return "Review and approve the planning package to unlock task generation.";
     case WORKFLOW_PHASE.TASKS:
       return "Generate tasks.md for the active feature workspace.";
     case WORKFLOW_PHASE.COMPLETE:

--- a/.opencode/src/workflow/resume-flow.ts
+++ b/.opencode/src/workflow/resume-flow.ts
@@ -27,13 +27,15 @@ function hasInitializedRepo(repoRoot: string): boolean {
 function resumeFlow(input: ResumeFlowInput): ResumeFlowResult {
   const hasResumeIntent = input.hasResumeIntent ?? false;
 
-  if (!input.activeFeature) {
+    if (!input.activeFeature) {
     if (!hasResumeIntent) {
       const evaluation = evaluateArtifactState({
         repoInitialized: hasInitializedRepo(input.repoRoot),
         specExists: false,
         planExists: false,
         tasksExists: false,
+        specApproved: false,
+        planApproved: false,
       });
 
       return {
@@ -52,6 +54,8 @@ function resumeFlow(input: ResumeFlowInput): ResumeFlowResult {
         specExists: false,
         planExists: false,
         tasksExists: false,
+        specApproved: false,
+        planApproved: false,
       });
 
       return {
@@ -69,6 +73,8 @@ function resumeFlow(input: ResumeFlowInput): ResumeFlowResult {
       specExists: context.artifacts.specExists,
       planExists: context.artifacts.planExists,
       tasksExists: context.artifacts.tasksExists,
+      specApproved: false,
+      planApproved: false,
     });
 
     return {
@@ -86,6 +92,8 @@ function resumeFlow(input: ResumeFlowInput): ResumeFlowResult {
     specExists: context.artifacts.specExists,
     planExists: context.artifacts.planExists,
     tasksExists: context.artifacts.tasksExists,
+    specApproved: false,
+    planApproved: false,
   });
 
   return {

--- a/.opencode/src/workflow/run-guided-sdd.ts
+++ b/.opencode/src/workflow/run-guided-sdd.ts
@@ -9,6 +9,8 @@ interface RunGuidedSddInput {
   activeFeature?: string;
   hasOutstandingClarifications?: boolean;
   clarificationContent?: string;
+  specApproved?: boolean;
+  planApproved?: boolean;
 }
 
 interface GuidedSddResult {
@@ -42,6 +44,8 @@ function runGuidedSdd(input: RunGuidedSddInput): GuidedSddResult {
     specExists: context.artifacts.specExists,
     planExists: context.artifacts.planExists,
     tasksExists: context.artifacts.tasksExists,
+    specApproved: input.specApproved ?? false,
+    planApproved: input.planApproved ?? false,
     hasOutstandingClarifications,
     hasResumeIntent: true,
   });

--- a/.opencode/src/workflow/session-state.ts
+++ b/.opencode/src/workflow/session-state.ts
@@ -1,8 +1,10 @@
 const WORKFLOW_PHASE = {
   INIT: "init",
   SPECIFY: "specify",
+  WAITING_SPEC_APPROVAL: "waiting_spec_approval",
   CLARIFY: "clarify",
   PLAN: "plan",
+  WAITING_PLAN_APPROVAL: "waiting_plan_approval",
   TASKS: "tasks",
   COMPLETE: "complete",
 } as const;
@@ -26,6 +28,8 @@ interface WorkflowRouteInput {
   specExists: boolean;
   planExists: boolean;
   tasksExists: boolean;
+  specApproved: boolean;
+  planApproved: boolean;
   hasOutstandingClarifications: boolean;
   hasResumeIntent: boolean;
 }
@@ -34,6 +38,8 @@ interface WorkflowSessionState {
   phase: WorkflowPhase;
   activeFeature: string;
   artifacts: ArtifactState[];
+  specApproved: boolean;
+  planApproved: boolean;
   nextRecommendation: string;
 }
 

--- a/.opencode/tests/unit/workflow/clarify-resume.test.ts
+++ b/.opencode/tests/unit/workflow/clarify-resume.test.ts
@@ -46,18 +46,20 @@ describe("clarify and resume workflows", () => {
     expect(detectActiveWorkspace(repoRoot)).toBe("feat-new-workflow");
   });
 
-  it("evaluates artifact state and routes to tasks when plan exists but tasks do not", () => {
+  it("evaluates artifact state and routes to waiting_plan_approval when plan exists but is not approved", () => {
     const evaluation = evaluateArtifactState({
       repoInitialized: true,
       specExists: true,
       planExists: true,
       tasksExists: false,
+      specApproved: true,
+      planApproved: false,
     });
 
-    expect(evaluation.phase).toBe(WORKFLOW_PHASE.TASKS);
+    expect(evaluation.phase).toBe(WORKFLOW_PHASE.WAITING_PLAN_APPROVAL);
   });
 
-  it("resumes the workflow from the latest feature workspace when resume intent is explicit", () => {
+  it("resumes conservatively to waiting_spec_approval when spec exists but approval state is unknown", () => {
     const repoRoot = mkdtempSync(path.join(tmpdir(), "sdd-resume-"));
     const featureRoot = path.join(repoRoot, "specs/feat-opencode-sdd-agent");
     mkdirSync(path.join(repoRoot, ".specify"));
@@ -68,8 +70,8 @@ describe("clarify and resume workflows", () => {
     const result = resumeFlow({ repoRoot, hasResumeIntent: true });
 
     expect(result.activeFeature).toBe("feat-opencode-sdd-agent");
-    expect(result.phase).toBe(WORKFLOW_PHASE.TASKS);
-    expect(result.nextRecommendation).toContain("tasks");
+    expect(result.phase).toBe(WORKFLOW_PHASE.WAITING_SPEC_APPROVAL);
+    expect(result.nextRecommendation).toContain("approve");
   });
 
   it("does not auto-resume without explicit resume intent", () => {

--- a/.opencode/tests/unit/workflow/guided-sdd.test.ts
+++ b/.opencode/tests/unit/workflow/guided-sdd.test.ts
@@ -52,7 +52,7 @@ describe("guided sdd workflow", () => {
     ]);
   });
 
-  it("routes a partially planned feature to the tasks phase", () => {
+  it("routes to waiting_spec_approval when no approval state is known", () => {
     const repoRoot = mkdtempSync(path.join(tmpdir(), "sdd-guided-"));
     const featureRoot = path.join(repoRoot, "specs/feat-opencode-sdd-agent");
     mkdirSync(featureRoot, { recursive: true });
@@ -63,6 +63,25 @@ describe("guided sdd workflow", () => {
     const result = runGuidedSdd({
       repoRoot,
       activeFeature: "feat-opencode-sdd-agent",
+    });
+
+    expect(result.phase).toBe(WORKFLOW_PHASE.WAITING_SPEC_APPROVAL);
+    expect(result.nextRecommendation).toContain("approve");
+  });
+
+  it("routes to tasks when both spec and plan are approved", () => {
+    const repoRoot = mkdtempSync(path.join(tmpdir(), "sdd-guided-"));
+    const featureRoot = path.join(repoRoot, "specs/feat-opencode-sdd-agent");
+    mkdirSync(featureRoot, { recursive: true });
+    mkdirSync(path.join(repoRoot, ".specify"));
+    writeFileSync(path.join(featureRoot, "spec.md"), "# spec\n");
+    writeFileSync(path.join(featureRoot, "plan.md"), "# plan\n");
+
+    const result = runGuidedSdd({
+      repoRoot,
+      activeFeature: "feat-opencode-sdd-agent",
+      specApproved: true,
+      planApproved: true,
     });
 
     expect(result.phase).toBe(WORKFLOW_PHASE.TASKS);

--- a/.opencode/tests/unit/workflow/phase-router.test.ts
+++ b/.opencode/tests/unit/workflow/phase-router.test.ts
@@ -11,6 +11,8 @@ describe("phase router", () => {
         specExists: false,
         planExists: false,
         tasksExists: false,
+        specApproved: false,
+        planApproved: false,
         hasOutstandingClarifications: false,
         hasResumeIntent: false,
       }),
@@ -24,23 +26,27 @@ describe("phase router", () => {
         specExists: true,
         planExists: false,
         tasksExists: false,
+        specApproved: false,
+        planApproved: false,
         hasOutstandingClarifications: true,
         hasResumeIntent: false,
       }),
     ).toBe(WORKFLOW_PHASE.CLARIFY);
   });
 
-  it("routes to tasks after the planning package exists", () => {
+  it("routes to waiting_plan_approval when plan exists but is not approved", () => {
     expect(
       determineNextPhase({
         repoInitialized: true,
         specExists: true,
         planExists: true,
         tasksExists: false,
+        specApproved: true,
+        planApproved: false,
         hasOutstandingClarifications: false,
         hasResumeIntent: false,
       }),
-    ).toBe(WORKFLOW_PHASE.TASKS);
+    ).toBe(WORKFLOW_PHASE.WAITING_PLAN_APPROVAL);
   });
 
   it("routes to specify for new session without resume intent", () => {
@@ -50,6 +56,8 @@ describe("phase router", () => {
         specExists: false,
         planExists: false,
         tasksExists: false,
+        specApproved: false,
+        planApproved: false,
         hasOutstandingClarifications: false,
         hasResumeIntent: false,
       }),
@@ -63,23 +71,57 @@ describe("phase router", () => {
         specExists: false,
         planExists: true,
         tasksExists: true,
+        specApproved: false,
+        planApproved: false,
         hasOutstandingClarifications: false,
         hasResumeIntent: false,
       }),
     ).toBe(WORKFLOW_PHASE.SPECIFY);
   });
 
-  it("routes to plan when resuming with existing spec", () => {
+  it("routes to waiting_spec_approval when spec exists but is not approved", () => {
     expect(
       determineNextPhase({
         repoInitialized: true,
         specExists: true,
         planExists: false,
         tasksExists: false,
+        specApproved: false,
+        planApproved: false,
+        hasOutstandingClarifications: false,
+        hasResumeIntent: true,
+      }),
+    ).toBe(WORKFLOW_PHASE.WAITING_SPEC_APPROVAL);
+  });
+
+  it("routes to plan when spec is approved and plan does not exist", () => {
+    expect(
+      determineNextPhase({
+        repoInitialized: true,
+        specExists: true,
+        planExists: false,
+        tasksExists: false,
+        specApproved: true,
+        planApproved: false,
         hasOutstandingClarifications: false,
         hasResumeIntent: true,
       }),
     ).toBe(WORKFLOW_PHASE.PLAN);
+  });
+
+  it("routes to tasks when plan is approved and tasks do not exist", () => {
+    expect(
+      determineNextPhase({
+        repoInitialized: true,
+        specExists: true,
+        planExists: true,
+        tasksExists: false,
+        specApproved: true,
+        planApproved: true,
+        hasOutstandingClarifications: false,
+        hasResumeIntent: true,
+      }),
+    ).toBe(WORKFLOW_PHASE.TASKS);
   });
 
   it("returns a concrete recommendation for the next phase", () => {

--- a/specs/fix-sequential-sdd-approval/data-model.md
+++ b/specs/fix-sequential-sdd-approval/data-model.md
@@ -1,0 +1,48 @@
+# Data Model: Require Sequential Approval Between Spec, Plan, and Tasks
+
+**Feature Branch**: `fix-sequential-sdd-approval`
+**Date**: 2026-03-21
+
+## Status: Workflow-state model only
+
+This change does not introduce application entities or persistence schemas. It extends the workflow state model used by the guided SDD flow.
+
+## Workflow Entities
+
+### Specification Stage
+
+- **Output**: `spec.md`
+- **Approval requirement**: Must be explicitly approved in the current session before planning can begin
+- **Key rule**: Artifact existence alone is not enough to unlock planning
+
+### Planning Stage
+
+- **Outputs**: `plan.md`, `research.md`, `data-model.md`, `quickstart.md`
+- **Approval requirement**: Must be explicitly approved in the current session before task generation can begin
+- **Key rule**: The planning package is treated as one reviewable unit for progression purposes
+
+### Task Preparation Stage
+
+- **Output**: `tasks.md`
+- **Input dependency**: Requires approved planning-stage artifacts
+- **Key rule**: Must not auto-generate only because plan files exist
+
+### Session Approval State
+
+- **Purpose**: Tracks whether the current session has approved the specification stage and the planning stage
+- **Fields**:
+  - `specApproved: boolean`
+  - `planApproved: boolean`
+- **Key rule**: Missing session approval state forces conservative resume behavior
+
+## Relationships
+
+- The **Specification Stage** feeds the **Planning Stage**
+- The **Planning Stage** feeds the **Task Preparation Stage**
+- The **Session Approval State** gates transitions between the stages
+
+## Invariants
+
+- `plan.md` must never be generated before `spec.md` is approved in the current session
+- `tasks.md` must never be generated before the planning package is approved in the current session
+- Resume logic must favor revalidation over auto-progression when approval state is unavailable

--- a/specs/fix-sequential-sdd-approval/plan.md
+++ b/specs/fix-sequential-sdd-approval/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Require Sequential Approval Between Spec, Plan, and Tasks
+
+**Branch**: `fix-sequential-sdd-approval` | **Date**: 2026-03-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/fix-sequential-sdd-approval/spec.md`
+
+## Summary
+
+Fix the guided SDD planning flow so it advances one stage at a time instead of feeling bundled together. The workflow should generate `spec.md`, stop for mandatory approval in the current session, then generate the planning package, stop again for mandatory approval, and only then generate `tasks.md` from the approved planning artifacts.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.8 with strict mode  
+**Primary Dependencies**: Bun runtime, `@opencode-ai/plugin`, existing workflow routing/helpers  
+**Storage**: Filesystem-backed planning artifacts under `specs/` plus in-memory session workflow state  
+**Testing**: Bun's built-in `bun:test` and TypeScript type-checking via `bunx tsc --noEmit`  
+**Target Platform**: OpenCode plugin runtime and guided repo-local SDD workflow  
+**Project Type**: OpenCode plugin with markdown-defined workflow commands and TypeScript routing logic  
+**Performance Goals**: Keep routing overhead negligible while adding explicit stage-gate evaluation  
+**Constraints**: Keep `Spec Driven` in plan mode, preserve markdown-only outputs, keep clarifications sequential, use session-scoped approvals rather than persisted approval files, and make resume conservative when approvals are unknown  
+**Scale/Scope**: Command contract updates, workflow state/routing changes, resume behavior changes, and workflow regression coverage
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- ✅ Change remains inside the existing Bun + TypeScript workflow architecture
+- ✅ `Spec Driven` stays in planning mode and continues producing markdown-only artifacts
+- ✅ Clarification remains explicit and sequential
+- ✅ Scope is limited to workflow control and artifact sequencing rather than implementation-mode behavior
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `.opencode/command/sdd.md` | **MODIFY** - Describe mandatory approval gates and sequential artifact generation clearly |
+| `.opencode/managed-assets/.opencode/command/sdd.md` | **MODIFY** - Keep bundled command contract aligned with repo-local command behavior |
+| `.opencode/src/workflow/session-state.ts` | **MODIFY** - Add session-scoped approval state and any waiting-for-approval phase modeling |
+| `.opencode/src/workflow/phase-router.ts` | **MODIFY** - Gate progression on approval state instead of artifact existence alone |
+| `.opencode/src/workflow/run-guided-sdd.ts` | **MODIFY** - Thread session approval state through guided routing and resume decisions |
+| `.opencode/src/workflow/resume-flow.ts` and related helpers | **MODIFY** - Revalidate stages conservatively when approval state is unavailable |
+| `.opencode/tests/unit/workflow/*.test.ts` | **MODIFY/CREATE** - Cover spec gate, plan gate, and conservative resume behavior |
+| `AGENTS.md` or workflow docs | **MODIFY if needed** - Keep documented stage order aligned with the fixed workflow |
+
+## File Details
+
+### 1. Command contract
+
+**Purpose**: Make the user-facing `/sdd` contract explicitly sequential.
+
+**Changes**:
+
+- Remove wording that implies the workflow will naturally produce everything in one pass
+- Explain that `spec.md` must be approved before planning begins
+- Explain that the planning package must be approved before `tasks.md` is generated
+
+### 2. Workflow state model
+
+**Purpose**: Represent approval gates directly in routing.
+
+**Changes**:
+
+- Add session-scoped approval flags for spec and plan
+- Distinguish generation phases from waiting-for-approval phases
+- Keep approval state session-local by design
+
+### 3. Routing and resume behavior
+
+**Purpose**: Stop eager progression and make resume safer.
+
+**Changes**:
+
+- Route to waiting states when approvals are missing
+- Only unlock planning after spec approval
+- Only unlock tasks after plan approval
+- When resuming without session approval state, stop at the latest completed stage and ask for revalidation
+
+### 4. Regression coverage
+
+**Purpose**: Prevent the workflow from reverting to “all at once” behavior.
+
+**Coverage targets**:
+
+- `spec.md` generation does not auto-trigger planning
+- Planning package generation does not auto-trigger tasks
+- Resume with existing artifacts but missing session approvals stops at the right gate
+- User-facing recommendations identify the pending approval stage correctly
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/fix-sequential-sdd-approval/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+.opencode/
+├── command/
+│   └── sdd.md
+├── managed-assets/
+│   └── .opencode/
+│       └── command/
+│           └── sdd.md
+├── src/
+│   └── workflow/
+│       ├── phase-router.ts
+│       ├── resume-flow.ts
+│       ├── run-guided-sdd.ts
+│       └── session-state.ts
+└── tests/
+    └── unit/
+        └── workflow/
+```
+
+**Structure Decision**: Keep the fix centered on the workflow engine and command contract so command wording and actual routing behavior remain aligned.
+
+## Complexity Tracking
+
+> No constitution violations. The added complexity is limited to explicit stage-gate state and related workflow tests.
+
+| Aspect | Status |
+|--------|--------|
+| Session-scoped approval model introduced | ✅ Required for explicit spec/plan gates |
+| Resume made intentionally conservative | ✅ Required because approvals are not persisted |
+| Command contract and runtime routing aligned | ✅ Prevents prompt-only fixes from drifting |

--- a/specs/fix-sequential-sdd-approval/quickstart.md
+++ b/specs/fix-sequential-sdd-approval/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart: Require Sequential Approval Between Spec, Plan, and Tasks
+
+## Goal
+
+Validate that `/sdd` now enforces sequential artifact generation with mandatory approval checkpoints between spec, plan, and tasks.
+
+## Prerequisites
+
+- OpenCode is configured to load the SDD plugin
+- The repo is already initialized for SDD workflow use
+- A clean or isolated feature workspace is available for guided-flow verification
+
+## Scenario 1: Spec generation stops for approval
+
+1. Start a new `/sdd` planning session for a feature.
+2. Let the workflow generate `spec.md`.
+3. Observe the next recommendation.
+
+**Expected result**: The workflow asks the user to review and approve `spec.md`; it does not generate planning artifacts yet.
+
+## Scenario 2: Spec approval unlocks planning only
+
+1. In the same session, explicitly approve the generated spec.
+2. Continue the `/sdd` flow.
+3. Verify `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` are generated.
+4. Observe the next recommendation.
+
+**Expected result**: The planning package is generated from `spec.md`, and the workflow stops again waiting for plan approval.
+
+## Scenario 3: Plan approval unlocks tasks only
+
+1. In the same session, explicitly approve the planning package.
+2. Continue the `/sdd` flow.
+3. Verify `tasks.md` is generated.
+
+**Expected result**: `tasks.md` is generated only after plan approval, using the planning package as its source context.
+
+## Scenario 4: Resume without approval state is conservative
+
+1. Start a session and generate `spec.md` or the planning package.
+2. End the session without carrying approval state forward.
+3. Resume the workflow later.
+
+**Expected result**: The workflow requests revalidation of the latest completed stage instead of auto-generating the next stage.
+
+## Follow-Up
+
+- After this fix lands, `/sdd` becomes a gated stage-by-stage planning flow rather than a bundled multi-artifact generator
+- Future work could persist approvals if resume ergonomics becomes more important than session-only simplicity

--- a/specs/fix-sequential-sdd-approval/research.md
+++ b/specs/fix-sequential-sdd-approval/research.md
@@ -1,0 +1,90 @@
+# Research: Require Sequential Approval Between Spec, Plan, and Tasks
+
+**Feature Branch**: `fix-sequential-sdd-approval`
+**Date**: 2026-03-21
+
+## Research Questions
+
+### Q1: What in the current workflow makes the stages feel bundled together?
+
+**Finding**: The command contract describes a logical order, but current guidance still emphasizes automatic task preparation and the router decides progression mostly from artifact existence.
+
+**Evidence**:
+- `.opencode/command/sdd.md` describes “automatic task preparation” and says tasks are generated once planning artifacts are complete
+- `.opencode/src/workflow/phase-router.ts` advances from spec absence to plan absence to tasks absence without explicit approval states
+
+**Decision**: Introduce mandatory approval checkpoints into the workflow contract and routing behavior.
+
+---
+
+### Q2: Where should approval state live for this change?
+
+**Finding**: The approved design choice is option A: session-controlled approval, not a persisted approval artifact in the workspace.
+
+**Evidence**:
+- User explicitly chose option `A`
+
+**Decision**: Keep approval state in session memory and make resume flows conservative when approval cannot be proven in the current session.
+
+---
+
+### Q3: What should be the exact stage boundaries?
+
+**Finding**: The desired boundaries are `spec -> plan package -> tasks`, where each next stage uses the previous approved stage as its input reference.
+
+**Evidence**:
+- User request explicitly says one file should be used as the reference to generate the next
+- Approved design requires spec approval before planning and plan approval before tasks
+
+**Decision**: Treat `spec.md` as the required input to planning, and treat `plan.md` plus `research.md`, `data-model.md`, and `quickstart.md` as the required inputs to tasks.
+
+---
+
+### Q4: How should resume work without persisted approvals?
+
+**Finding**: Since approvals are session-scoped, resume cannot safely assume prior approvals just because files exist.
+
+**Evidence**:
+- The current route input tracks artifact existence and clarifications, but not persistent approval markers
+- Session-only approval was chosen intentionally for implementation simplicity
+
+**Decision**: Resume should stop at the latest completed stage and ask for revalidation when current-session approval state is missing.
+
+---
+
+### Q5: What should remain unchanged?
+
+**Finding**: The workflow must remain markdown-only in `Spec Driven`, continue to use clarification loops, and avoid destructive behavior.
+
+**Evidence**:
+- `.opencode/command/sdd.md` requires markdown-only planning outputs
+- Existing command contract already treats clarification as a separate step for high-impact ambiguity
+
+**Decision**: Add approval gates without broadening the agent into implementation or weakening clarification rules.
+
+## Technical Decisions Summary
+
+| Decision | Rationale |
+|----------|-----------|
+| Add mandatory session-scoped approval gates | Fixes eager progression without requiring new persisted approval files |
+| Make resume conservative when approvals are unknown | Prevents accidental stage skipping |
+| Use approved prior-stage artifacts as explicit inputs to next stage | Matches the user’s desired sequential planning model |
+| Update both command contract and workflow routing | Prevents the behavior from depending only on prompt wording |
+
+## Risks Identified
+
+1. **Risk**: Session approval state is lost between interactions  
+   **Mitigation**: Resume recommends revalidation instead of auto-progression
+
+2. **Risk**: Users edit generated artifacts after approval  
+   **Mitigation**: Recompute readiness and require reapproval when the approved stage changes materially
+
+3. **Risk**: Command wording and router logic drift apart  
+   **Mitigation**: Update both `sdd.md` and workflow routing tests together
+
+## References
+
+- `.opencode/command/sdd.md`
+- `.opencode/src/workflow/phase-router.ts`
+- `.opencode/src/workflow/run-guided-sdd.ts`
+- `.opencode/src/workflow/session-state.ts`

--- a/specs/fix-sequential-sdd-approval/spec.md
+++ b/specs/fix-sequential-sdd-approval/spec.md
@@ -1,0 +1,106 @@
+# Spec: Require Sequential Approval Between Spec, Plan, and Tasks
+
+**Feature Branch**: `fix-sequential-sdd-approval`  
+**Created**: 2026-03-21  
+**Status**: Draft  
+**Input**: User description: "faça um ajuste, na etapa de spec, plan e tasks devem ser executadas na sequência, ou seja, um arquivo deve ser usado como referencia para gerar o proximo. o comportamento visto tem sido fazer tudo meio que junto. acho que faz sentido abrir a possibilidade para validar cada etapa junto ao usuário." with clarifications: approval is `obrigatório` and approval tracking uses option `A` (session-controlled approval)
+
+> Primary guided workflow: `/sdd` (with `speckit.*` compatibility wrappers)
+
+## Problem
+
+The current `/sdd` workflow describes a logical order of `spec -> plan -> tasks`, but in practice the experience still feels too eager and bundled together. The workflow can progress based mostly on artifact existence, which makes it easier for planning stages to blur together instead of clearly using one artifact as the approved input for the next stage.
+
+That weakens user review, makes the generated plan feel less deliberate, and makes `tasks.md` look auto-produced from incomplete or unvalidated planning context. The user wants each stage to stop, be reviewed, and only then unlock the next stage.
+
+## Goal
+
+Make the guided SDD flow strictly sequential so `spec.md`, `plan.md`, and `tasks.md` are generated in order, with mandatory user approval checkpoints between `spec -> plan` and `plan -> tasks` within the active session.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Spec approval gates planning (Priority: P1)
+
+A user starts `/sdd` for a new feature and wants the workflow to stop after `spec.md` so they can validate the specification before any planning package is generated.
+
+**Why this priority**: This is the first required gate and fixes the main complaint that spec and plan currently feel blended together.
+
+**Independent Test**: Start a guided planning session, let `/sdd` produce `spec.md`, and verify the workflow recommends spec review/approval instead of generating `plan.md` immediately.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new feature workspace with no artifacts, **When** `/sdd` completes the specify step, **Then** `spec.md` is generated and the workflow stops to request explicit user approval before planning
+2. **Given** `spec.md` exists but the current session has no recorded spec approval, **When** `/sdd` runs again, **Then** it recommends reviewing and approving the spec instead of generating `plan.md`
+3. **Given** the user explicitly approves the spec in the active session, **When** `/sdd` continues, **Then** the planning package is generated using `spec.md` as the input reference
+
+---
+
+### User Story 2 - Plan approval gates task generation (Priority: P1)
+
+A user reviews the planning package and wants `tasks.md` to be generated only after they have explicitly approved the plan stage.
+
+**Why this priority**: The plan-to-tasks boundary is where downstream execution quality is decided, so it must be gated just as strongly as the spec-to-plan boundary.
+
+**Independent Test**: Generate `plan.md`, `research.md`, `data-model.md`, and `quickstart.md`, then verify `/sdd` requests plan approval and does not generate `tasks.md` until approval is recorded in the current session.
+
+**Acceptance Scenarios**:
+
+1. **Given** the planning package exists and no plan approval is recorded in the current session, **When** `/sdd` runs, **Then** it recommends reviewing and approving the plan stage instead of generating `tasks.md`
+2. **Given** the user approves the plan stage in the active session, **When** `/sdd` continues, **Then** `tasks.md` is generated using `plan.md` and the planning artifacts as its source inputs
+3. **Given** `tasks.md` has not been generated yet, **When** the plan stage has not been approved, **Then** the workflow must not auto-progress to tasks based only on file existence
+
+---
+
+### User Story 3 - Resume flow stays conservative without approval state (Priority: P2)
+
+A user resumes planning in a later interaction and needs the workflow to behave safely when the session cannot prove prior approvals.
+
+**Why this priority**: Session-based approvals are simpler to implement, but they require clear fallback behavior so resume does not silently skip review gates.
+
+**Independent Test**: Create a workspace with `spec.md` or the planning package present, clear session approval state, and verify the workflow asks for revalidation instead of jumping ahead.
+
+**Acceptance Scenarios**:
+
+1. **Given** `spec.md` exists from a previous session and no approval state is available now, **When** the workflow resumes, **Then** it asks for spec approval again before planning
+2. **Given** `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` exist from a previous session and no approval state is available now, **When** the workflow resumes, **Then** it asks for plan approval again before tasks
+3. **Given** the user wants to continue a partially completed workspace, **When** session approval state is missing, **Then** the workflow favors revalidation over automatic progression
+
+---
+
+### Edge Cases
+
+- The user edits `spec.md` after first approval in the same session; the workflow should treat that as requiring renewed review before planning continues
+- The user edits `plan.md` or derived planning artifacts after plan approval in the same session; the workflow should require renewed review before generating tasks
+- The workflow resumes in a later interaction where the files exist but the in-session approval state does not
+- The user explicitly asks to inspect current state rather than continue; the workflow should report the pending approval gate clearly
+- Clarification loops must still complete before an approval gate is considered satisfied for the current stage
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `/sdd` workflow MUST treat `spec.md`, `plan.md`, and `tasks.md` as sequential outputs where each stage depends on the approved output of the prior stage
+- **FR-002**: The workflow MUST stop after generating `spec.md` and require explicit user approval before generating `plan.md` or any derived planning artifacts
+- **FR-003**: The workflow MUST generate `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` only after `spec.md` has been approved in the active session
+- **FR-004**: The workflow MUST stop after generating the planning package and require explicit user approval before generating `tasks.md`
+- **FR-005**: The workflow MUST generate `tasks.md` only after the plan stage has been approved in the active session and must use `plan.md` plus supporting planning artifacts as inputs
+- **FR-006**: Resume behavior MUST not infer stage approval only from artifact existence; when current-session approval state is absent, the workflow MUST request revalidation of the latest completed stage
+- **FR-007**: The next-step recommendation returned by the workflow MUST clearly indicate whether the user needs to review/approve spec, review/approve plan, or proceed to the next artifact-generation stage
+- **FR-008**: Clarification handling MUST remain sequential and MUST complete before a stage can be considered ready for approval
+- **FR-009**: The updated workflow contract and command guidance MUST explicitly describe the mandatory approval gates between `spec -> plan` and `plan -> tasks`
+
+### Key Entities
+
+- **Session Approval State**: In-memory workflow state that records whether the current session has explicitly approved the spec stage and the plan stage
+- **Specification Stage**: The phase that produces `spec.md` and must be reviewed before any planning package is generated
+- **Planning Stage**: The phase that produces `plan.md`, `research.md`, `data-model.md`, and `quickstart.md`, and must be reviewed before tasks are generated
+- **Task Preparation Stage**: The phase that produces `tasks.md` from the approved planning package
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a guided planning session, `plan.md` is never generated before `spec.md` exists and receives explicit approval in that same session
+- **SC-002**: In a guided planning session, `tasks.md` is never generated before the planning package exists and receives explicit approval in that same session
+- **SC-003**: Resume-flow tests prove that artifact existence alone does not auto-advance the workflow past a required approval gate
+- **SC-004**: Workflow messaging consistently tells the user which stage is waiting for approval and what explicit action is needed to continue

--- a/specs/fix-sequential-sdd-approval/tasks.md
+++ b/specs/fix-sequential-sdd-approval/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Require Sequential Approval Between Spec, Plan, and Tasks
+
+**Input**: Design documents from `/specs/fix-sequential-sdd-approval/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, quickstart.md ✅
+
+**Tests**: Workflow regression coverage is required because this fix changes routing and approval behavior.
+
+**Organization**: Tasks are grouped by user story so spec gating, plan gating, and conservative resume behavior can be validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task supports
+
+---
+
+## Phase 1: Foundation - Model session approval gates
+
+**Purpose**: Introduce the workflow concepts needed for explicit stage approvals.
+
+- [ ] T001 Extend workflow/session types to represent session-scoped approval state for spec and plan
+- [ ] T002 Update phase recommendations or route modeling to distinguish generation phases from approval-waiting phases
+- [ ] T003 Update shared workflow guidance so sequential stage gating is part of the canonical `/sdd` contract
+
+**Checkpoint**: The workflow model can represent “waiting for spec approval” and “waiting for plan approval.”
+
+---
+
+## Phase 2: User Story 1 - Spec approval gates planning (Priority: P1) 🎯 MVP
+
+**Goal**: The workflow stops after `spec.md` and requires approval before planning.
+
+**Independent Test**: Generate `spec.md` in a fresh session and verify the workflow requests approval instead of generating `plan.md`.
+
+### Tests for User Story 1
+
+- [ ] T004 [P] [US1] Add routing tests for “spec exists but spec approval is false” in `.opencode/tests/unit/workflow/`
+- [ ] T005 [P] [US1] Add guided-flow tests proving `plan.md` is blocked until current-session spec approval is true
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Update `.opencode/src/workflow/session-state.ts` to model spec approval state
+- [ ] T007 [US1] Update `.opencode/src/workflow/phase-router.ts` to stop at a spec-approval gate before planning
+- [ ] T008 [US1] Update `.opencode/src/workflow/run-guided-sdd.ts` to pass session approval state into phase routing
+- [ ] T009 [US1] Update `.opencode/command/sdd.md` so the workflow contract explicitly tells the user to approve spec before planning continues
+
+**Checkpoint**: Spec generation and spec approval are now separate steps.
+
+---
+
+## Phase 3: User Story 2 - Plan approval gates task generation (Priority: P1)
+
+**Goal**: The workflow stops after the planning package and requires approval before `tasks.md`.
+
+**Independent Test**: Generate the planning package and verify `tasks.md` is blocked until current-session plan approval is true.
+
+### Tests for User Story 2
+
+- [ ] T010 [P] [US2] Add routing tests for “plan exists but plan approval is false” in `.opencode/tests/unit/workflow/`
+- [ ] T011 [P] [US2] Add guided-flow tests proving `tasks.md` is blocked until current-session plan approval is true
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Extend `.opencode/src/workflow/session-state.ts` to model plan approval state
+- [ ] T013 [US2] Update `.opencode/src/workflow/phase-router.ts` to stop at a plan-approval gate before tasks
+- [ ] T014 [US2] Update `.opencode/command/sdd.md` so task generation is described as post-approval rather than eager automatic progression
+- [ ] T015 [US2] Ensure task-generation handoff guidance still uses the planning package as its declared source input
+
+**Checkpoint**: Plan generation and task generation are now separated by explicit approval.
+
+---
+
+## Phase 4: User Story 3 - Resume flow stays conservative without approval state (Priority: P2)
+
+**Goal**: Resume behavior revalidates stages instead of skipping gates when approval state is missing.
+
+**Independent Test**: Resume a workspace with existing artifacts but no current-session approval state and verify the workflow requests reapproval at the right stage.
+
+### Tests for User Story 3
+
+- [ ] T016 [P] [US3] Add resume-flow tests for existing `spec.md` without current-session approval
+- [ ] T017 [P] [US3] Add resume-flow tests for existing planning package without current-session approval
+
+### Implementation for User Story 3
+
+- [ ] T018 [US3] Update `.opencode/src/workflow/run-guided-sdd.ts` and related resume logic to prefer revalidation when session approval is unknown
+- [ ] T019 [US3] Update user-facing recommendations so resumed sessions explain which stage needs reapproval and why
+
+**Checkpoint**: Resume does not bypass approval gates based only on artifact presence.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Verification
+
+- [ ] T020 Run typecheck for `.opencode/`
+- [ ] T021 Run workflow unit tests covering routing, guided flow, and resume behavior
+- [ ] T022 Run the guided verification scenarios from `specs/fix-sequential-sdd-approval/quickstart.md`
+- [ ] T023 Confirm `/sdd` now progresses as `spec -> approve -> plan package -> approve -> tasks`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1**: No dependencies; it introduces the approval-gate model
+- **Phase 2**: Depends on Phase 1 because spec gating needs the approval-state model
+- **Phase 3**: Depends on Phase 1 and should follow Phase 2 so the full sequential path can be verified end to end
+- **Phase 4**: Depends on Phases 2-3 because conservative resume behavior must respect both gates
+- **Phase 5**: Depends on all previous phases
+
+### Parallel Opportunities
+
+- T004 and T005 can run in parallel
+- T010 and T011 can run in parallel
+- T016 and T017 can run in parallel
+
+---
+
+## Notes
+
+- This fix intentionally keeps approvals session-scoped rather than persisted in the workspace
+- Resume therefore favors safety and revalidation over convenience
+- The command contract and routing logic must be updated together so the workflow no longer feels “all at once”


### PR DESCRIPTION
## Summary
- Add mandatory approval gates between spec→plan and plan→tasks phases
- Approval state is session-scoped (not persisted), conservative resume when unknown
- Add `WAITING_SPEC_APPROVAL` and `WAITING_PLAN_APPROVAL` phases
- Update phase-router with two new routing gates
- Update all callers to pass/respect approval state
- Sync managed-assets sdd.md with command sdd.md
- 96 tests pass, TypeScript clean

## Phase flow enforced
spec → [user approves] → plan → [user approves] → tasks