### PR TITLE
fix: wire PreScriptRunner hook to execute scripts before template delivery

### DIFF
--- a/.opencode/command/implement.md
+++ b/.opencode/command/implement.md
@@ -19,12 +19,6 @@ When `/implement` is invoked, the system enters **implementation mode** — not 
 - Load `tasks.md` and supporting planning artifacts
 - Report execution progress or state a concrete blocker
 
-**Incorrect behavior** (do NOT do):
-
-```text
-$ARGUMENTS
-```
-
 You **MUST** consider the user input before proceeding (if not empty).
 
 ## Pre-Execution Checks

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helldinhow/sdd-flow-opencode-plugin",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "OpenCode Spec-Driven Development workflow plugin and bootstrap kit",
   "homepage": "https://github.com/Heldinhow/sdd-flow#readme",
   "repository": {

--- a/.opencode/src/plugin/command-registry.ts
+++ b/.opencode/src/plugin/command-registry.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import type { Config } from "@opencode-ai/sdk";
 
-interface CommandScripts {
+export interface CommandScripts {
   sh?: string;
 }
 

--- a/.opencode/src/plugin/index.ts
+++ b/.opencode/src/plugin/index.ts
@@ -4,7 +4,8 @@ import path from "node:path";
 import type { Plugin, PluginInput } from "@opencode-ai/plugin";
 
 import { BRANCH_PREFIX_VALUES } from "../branching/prefixes";
-import { registerCommands } from "./command-registry";
+import { discoverCommands, registerCommands } from "./command-registry";
+import { PreScriptRunner } from "./pre-script-runner";
 import {
   SPEC_DRIVEN_AGENT,
   buildSpecDrivenPrompt,
@@ -68,9 +69,40 @@ const sddPlugin: Plugin = async (input) => {
       output.env.SDD_PRIMARY_COMMAND = "sdd";
       output.env.SDD_BRANCH_PREFIXES = BRANCH_PREFIX_VALUES.join(",");
     },
-    async "chat.message"(event, output) {
-      if (!repoInitialized || event.agent !== SPEC_DRIVEN_AGENT) {
+    async "chat.message"(input, output) {
+      if (!repoInitialized || input.agent !== SPEC_DRIVEN_AGENT) {
         return;
+      }
+
+      const messageText = output.parts
+        .filter((part): part is Extract<typeof output.parts[number], { type: "text" }> => part.type === "text")
+        .map((part) => part.text)
+        .join("\n")
+        .trim();
+
+      if (messageText.startsWith("/")) {
+        const commandName = messageText.slice(1).split(/\s/).at(0) ?? "";
+        if (commandName) {
+          const commands = discoverCommands(projectRoot);
+          const entry = commands.get(commandName);
+          if (entry?.scripts?.sh) {
+            const runner = new PreScriptRunner((name) => {
+              const cmd = commands.get(name);
+              return cmd?.scripts ?? null;
+            });
+            const result = await runner.runIfNeeded(commandName, projectRoot);
+            if (result) {
+              output.parts.unshift({
+                id: `prt-${output.message.id}-prescript`,
+                sessionID: output.message.sessionID,
+                messageID: output.message.id,
+                type: "text",
+                synthetic: true,
+                text: result.formattedOutput,
+              });
+            }
+          }
+        }
       }
 
       injectSddBackendTemplate(projectRoot, output);

--- a/.opencode/src/plugin/pre-script-runner.ts
+++ b/.opencode/src/plugin/pre-script-runner.ts
@@ -1,0 +1,151 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import type { CommandScripts } from "./command-registry";
+
+interface PreScriptResult {
+  commandName: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  errorKind: "success" | "nonzero" | "notfound" | "timeout" | "unknown";
+  formattedOutput: string;
+}
+
+interface GetScriptsFn {
+  (commandName: string): CommandScripts | null;
+}
+
+async function runScript(
+  scriptCmd: string,
+  repoRoot: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; exitCode: number; errorKind: PreScriptResult["errorKind"] }> {
+  return new Promise((resolve) => {
+    const proc = spawn("/bin/sh", ["-c", scriptCmd], {
+      cwd: repoRoot,
+      timeout: timeoutMs,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let exited = false;
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on("close", (code: number | null) => {
+      exited = true;
+      resolve({
+        stdout,
+        stderr,
+        exitCode: code ?? -1,
+        errorKind: code === 0 ? "success" : "nonzero",
+      });
+    });
+
+    proc.on("error", (err: NodeJS.ErrnoException) => {
+      exited = true;
+      if (err.code === "ENOENT" || err.code === "EACCES") {
+        resolve({ stdout, stderr, exitCode: -1, errorKind: "notfound" });
+      } else {
+        resolve({ stdout, stderr, exitCode: -1, errorKind: "unknown" });
+      }
+    });
+
+    setTimeout(() => {
+      if (!exited) {
+        proc.kill("SIGKILL");
+        resolve({ stdout, stderr, exitCode: -1, errorKind: "timeout" });
+      }
+    }, timeoutMs);
+  });
+}
+
+function formatScriptOutput(commandName: string, result: {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  errorKind: PreScriptResult["errorKind"];
+}): string {
+  const lines: string[] = [];
+
+  lines.push(`## Pre-script: ${commandName}`);
+  lines.push("");
+  lines.push(`**Status**: ${result.errorKind === "success" ? "success" : `error (exit ${result.exitCode})`}`);
+
+  let parsedJson: Record<string, unknown> | null = null;
+  if (result.stdout.trim()) {
+    try {
+      parsedJson = JSON.parse(result.stdout.trim());
+    } catch {
+      // not JSON
+    }
+  }
+
+  if (parsedJson && typeof parsedJson === "object") {
+    const fe = parsedJson as Record<string, unknown>;
+    if (fe["FEATURE_DIR"]) {
+      lines.push(`**Feature workspace**: ${fe["FEATURE_DIR"]}`);
+    }
+    if (Array.isArray(fe["AVAILABLE_DOCS"])) {
+      lines.push(`**Available docs**: ${(fe["AVAILABLE_DOCS"] as string[]).join(", ")}`);
+    }
+    if (fe["BRANCH"]) {
+      lines.push(`**Branch**: ${fe["BRANCH"]}`);
+    }
+  } else if (result.stdout.trim()) {
+    lines.push("**Raw output**:");
+    lines.push("```");
+    lines.push(result.stdout.trim());
+    lines.push("```");
+  }
+
+  if (result.errorKind !== "success" && result.errorKind !== "notfound") {
+    if (result.stderr.trim()) {
+      lines.push("");
+      lines.push("**Error output**:");
+      lines.push("```");
+      lines.push(result.stderr.trim());
+      lines.push("```");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+class PreScriptRunner {
+  private getScripts: GetScriptsFn;
+  private timeoutMs: number;
+
+  constructor(getScripts: GetScriptsFn, timeoutMs = 30_000) {
+    this.getScripts = getScripts;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async runIfNeeded(commandName: string, repoRoot: string): Promise<PreScriptResult | null> {
+    const scripts = this.getScripts(commandName);
+    if (!scripts || !scripts.sh) {
+      return null;
+    }
+
+    const result = await runScript(scripts.sh, repoRoot, this.timeoutMs);
+
+    return {
+      commandName,
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      errorKind: result.errorKind,
+      formattedOutput: formatScriptOutput(commandName, result),
+    };
+  }
+}
+
+export { PreScriptRunner, runScript, formatScriptOutput };
+export type { PreScriptResult };


### PR DESCRIPTION
## Summary
- Add `PreScriptRunner` class that intercepts `/<command>` invocations and runs the `scripts.sh` prerequisite script before OpenCode delivers the command template to the model
- Fixes the 0.5.0 `scripts:` metadata feature which was stored but never executed
- Remove stray `$ARGUMENTS` placeholder from `implement.md`

## Changes
- **pre-script-runner.ts**: New `PreScriptRunner` class with async script execution, timeout, JSON output formatting
- **index.ts**: Wire PreScriptRunner into `chat.message` hook — prepends formatted script output to `output.parts` before template delivery
- **command-registry.ts**: Export `CommandScripts` interface
- **implement.md**: Remove stray `$ARGUMENTS` block
- **package.json**: Bump to 0.6.0