### PR TITLE
fix: add top-level agent: build to command frontmatter

### DIFF
--- a/.opencode/command/implement.md
+++ b/.opencode/command/implement.md
@@ -1,5 +1,6 @@
 ---
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md. Switches to build agent for code execution. When invoked, this command loads the active feature workspace, locates tasks.md, and begins implementation — it does NOT explain the command markdown file.
+agent: build
 handoffs:
   - label: Implement Tasks
     agent: build

--- a/.opencode/command/sdd-init.md
+++ b/.opencode/command/sdd-init.md
@@ -1,5 +1,6 @@
 ---
 description: Initialize SDD workflow in a repository — creates all required directories, files, templates, and constitution interactively. Must be run before Spec Driven agent can be used.
+agent: build
 handoffs:
   - label: Initialize Repository
     agent: build

--- a/.opencode/command/speckit.implement.md
+++ b/.opencode/command/speckit.implement.md
@@ -1,5 +1,6 @@
 ---
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+agent: build
 handoffs:
   - label: Implement Tasks
     agent: build

--- a/.opencode/managed-assets/.opencode/command/implement.md
+++ b/.opencode/managed-assets/.opencode/command/implement.md
@@ -1,5 +1,6 @@
 ---
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md. Switches to build agent for code execution.
+agent: build
 handoffs:
   - label: Implement Tasks
     agent: build

--- a/.opencode/managed-assets/.opencode/command/sdd-init.md
+++ b/.opencode/managed-assets/.opencode/command/sdd-init.md
@@ -1,5 +1,6 @@
 ---
 description: Initialize SDD workflow in a repository — creates all required directories, files, templates, and constitution interactively. Must be run before Spec Driven agent can be used.
+agent: build
 handoffs:
   - label: Initialize Repository
     agent: build

--- a/.opencode/managed-assets/.opencode/command/speckit.implement.md
+++ b/.opencode/managed-assets/.opencode/command/speckit.implement.md
@@ -1,5 +1,6 @@
 ---
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+agent: build
 handoffs:
   - label: Implement Tasks
     agent: build


### PR DESCRIPTION
## Summary

OpenCode only reads the **top-level `agent` field** to switch agents before delivering the command template. The `handoffs[].agent` structure was our custom extension that OpenCode doesn't natively understand.

**Root cause**: Commands had `handoffs[].agent` but no top-level `agent` field, so OpenCode defaulted to the current agent (Spec Driven) which has `edit: deny` permissions. The model would receive the template but couldn't create directories or run init scripts.

**Fix**: Add `agent: build` at the top level of command frontmatter so OpenCode switches to the build agent (full permissions) before delivering the template.

## Changes

- `.opencode/command/sdd-init.md`: Added `agent: build`
- `.opencode/command/implement.md`: Added `agent: build`
- `.opencode/command/speckit.implement.md`: Added `agent: build`
- Same fixes applied to `managed-assets/` template versions

## How it works now

1. User types `/sdd-init`
2. OpenCode reads top-level `agent: build` from command frontmatter
3. OpenCode switches to build agent before delivering template
4. Build agent receives the template with full edit/bash permissions
5. Init checklist can now create directories and files