### PR TITLE
fix(plugin): execute slash command pre-scripts before templates

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helldinhow/sdd-flow-opencode-plugin",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "OpenCode Spec-Driven Development workflow plugin and bootstrap kit",
   "homepage": "https://github.com/Heldinhow/sdd-flow#readme",
   "repository": {

--- a/.opencode/src/plugin/command-registry.ts
+++ b/.opencode/src/plugin/command-registry.ts
@@ -10,6 +10,7 @@ export interface CommandScripts {
 
 interface CommandFrontmatter {
   description?: string;
+  agent?: string;
   handoffs?: Array<{
     label: string;
     agent: string;
@@ -20,6 +21,7 @@ interface CommandFrontmatter {
 
 interface CommandEntry {
   template: string;
+  filePath: string;
   description?: string;
   agent?: string;
   scripts?: CommandScripts;
@@ -52,6 +54,11 @@ function parseYamlFrontmatter(content: string): CommandFrontmatter | null {
   const descriptionMatch = frontmatterText.match(/^description:\s*(.+)$/m);
   if (descriptionMatch) {
     result.description = descriptionMatch[1].trim();
+  }
+
+  const agentMatch = frontmatterText.match(/^agent:\s*(.+)$/m);
+  if (agentMatch) {
+    result.agent = agentMatch[1].trim();
   }
 
   const handoffsMatch = frontmatterText.match(/^handoffs:\s*\n((?:[ \t]+-[^\n]*(?:\n[ \t]+[^\n]+)*\n?)*)/m);
@@ -131,14 +138,19 @@ function discoverCommands(projectRoot: string): Map<string, CommandEntry> {
 
     const frontmatter = parseYamlFrontmatter(content);
     const entry: CommandEntry = {
-      template: path.join(...COMMANDS_DIR, file),
+      template: filePath,
+      filePath,
     };
 
     if (frontmatter?.description) {
       entry.description = frontmatter.description;
     }
 
-    if (frontmatter?.handoffs && frontmatter.handoffs.length > 0) {
+    if (frontmatter?.agent) {
+      entry.agent = frontmatter.agent;
+    }
+
+    if (!entry.agent && frontmatter?.handoffs && frontmatter.handoffs.length > 0) {
       entry.agent = frontmatter.handoffs[0].agent;
     }
 
@@ -166,7 +178,6 @@ function registerCommands(config: Config, projectRoot: string): void {
       template: entry.template,
       description: entry.description,
       agent: entry.agent,
-      scripts: entry.scripts,
     } as never;
   }
 }

--- a/.opencode/src/plugin/index.ts
+++ b/.opencode/src/plugin/index.ts
@@ -48,9 +48,24 @@ function buildSystemContext(projectRoot: string): string[] {
   ];
 }
 
+function buildSyntheticPartIds(sessionID: string, commandName: string): { id: string; messageID: string } {
+  const slug = commandName.replace(/[^a-zA-Z0-9._-]/g, "-");
+
+  return {
+    id: `prt-${sessionID}-${slug}-prescript`,
+    messageID: `msg-${sessionID}-${slug}-prescript`,
+  };
+}
+
 const sddPlugin: Plugin = async (input) => {
   const projectRoot = resolveProjectRoot(input);
   const repoInitialized = hasSddMarkers(projectRoot);
+  const runner = new PreScriptRunner((name) => {
+    const commands = discoverCommands(projectRoot);
+    const entry = commands.get(name);
+
+    return entry?.scripts ?? null;
+  });
 
   return {
     async config(config) {
@@ -74,38 +89,23 @@ const sddPlugin: Plugin = async (input) => {
         return;
       }
 
-      const messageText = output.parts
-        .filter((part): part is Extract<typeof output.parts[number], { type: "text" }> => part.type === "text")
-        .map((part) => part.text)
-        .join("\n")
-        .trim();
-
-      if (messageText.startsWith("/")) {
-        const commandName = messageText.slice(1).split(/\s/).at(0) ?? "";
-        if (commandName) {
-          const commands = discoverCommands(projectRoot);
-          const entry = commands.get(commandName);
-          if (entry?.scripts?.sh) {
-            const runner = new PreScriptRunner((name) => {
-              const cmd = commands.get(name);
-              return cmd?.scripts ?? null;
-            });
-            const result = await runner.runIfNeeded(commandName, projectRoot);
-            if (result) {
-              output.parts.unshift({
-                id: `prt-${output.message.id}-prescript`,
-                sessionID: output.message.sessionID,
-                messageID: output.message.id,
-                type: "text",
-                synthetic: true,
-                text: result.formattedOutput,
-              });
-            }
-          }
-        }
+      injectSddBackendTemplate(projectRoot, output);
+    },
+    async "command.execute.before"(input, output) {
+      const result = await runner.runIfNeeded(input.command, projectRoot);
+      if (!result) {
+        return;
       }
 
-      injectSddBackendTemplate(projectRoot, output);
+      const ids = buildSyntheticPartIds(input.sessionID, input.command);
+      output.parts.unshift({
+        id: ids.id,
+        sessionID: input.sessionID,
+        messageID: ids.messageID,
+        type: "text",
+        synthetic: true,
+        text: result.formattedOutput,
+      });
     },
     async "experimental.chat.system.transform"(_event, output) {
       if (!repoInitialized) {

--- a/.opencode/tests/unit/plugin/command-registry.test.ts
+++ b/.opencode/tests/unit/plugin/command-registry.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 
-import { discoverCommands, parseYamlFrontmatter } from "../../../src/plugin/command-registry";
+import { discoverCommands, parseYamlFrontmatter, registerCommands } from "../../../src/plugin/command-registry";
 
 describe("command-registry", () => {
   describe("parseYamlFrontmatter", () => {
@@ -205,7 +205,23 @@ description: SDD command
       const entry = commands.get("sdd");
 
       expect(entry).toBeDefined();
-      expect(entry!.template).toBe(".opencode/command/sdd.md");
+      expect(entry!.template).toBe(path.join(testRoot, ".opencode", "command", "sdd.md"));
+
+      rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    it("registers bundled commands with resolvable template paths before repo init", () => {
+      const testRoot = path.join(tmpdir(), "sdd-bundle-config-" + Date.now());
+      rmSync(testRoot, { recursive: true, force: true });
+      mkdirSync(testRoot, { recursive: true });
+
+      const config = {} as Parameters<typeof registerCommands>[0];
+      registerCommands(config, testRoot);
+
+      expect(config.command).toBeDefined();
+      expect(config.command?.["sdd-init"]).toBeDefined();
+      expect(config.command?.["sdd-init"]?.template).toContain("managed-assets");
+      expect(config.command?.["sdd-init"]?.template).toEndWith(path.join(".opencode", "command", "sdd-init.md"));
 
       rmSync(testRoot, { recursive: true, force: true });
     });

--- a/.opencode/tests/unit/plugin/index.test.ts
+++ b/.opencode/tests/unit/plugin/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, mkdirSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -151,6 +151,73 @@ describe("sdd plugin", () => {
       type: "text",
       text: "/implement",
     });
+  });
+
+  it("runs pre-scripts through command.execute.before for slash commands", async () => {
+    const projectRoot = mkdtempSync(path.join(tmpdir(), "sdd-plugin-command-hook-"));
+    mkdirSync(path.join(projectRoot, ".specify", "scripts", "bash"), { recursive: true });
+    mkdirSync(path.join(projectRoot, "specs"));
+    await Bun.write(
+      path.join(projectRoot, ".specify", "scripts", "bash", "check-prerequisites.sh"),
+      "#!/bin/sh\nprintf '%s\\n' '{\"FEATURE_DIR\":\"/tmp/feat-auth\",\"AVAILABLE_DOCS\":[\"tasks.md\",\"plan.md\"]}'\n",
+    );
+    chmodSync(path.join(projectRoot, ".specify", "scripts", "bash", "check-prerequisites.sh"), 0o755);
+
+    const hooks = await sddPlugin(createPluginInput(projectRoot));
+    const output = {
+      parts: [],
+    } as Parameters<NonNullable<PluginHooks["command.execute.before"]>>[1];
+
+    await hooks["command.execute.before"]?.(
+      {
+        command: "implement",
+        sessionID: "session_1",
+        arguments: "",
+      },
+      output,
+    );
+
+    expect(output.parts).toHaveLength(1);
+    expect(output.parts[0]).toMatchObject({
+      type: "text",
+      synthetic: true,
+      sessionID: "session_1",
+    });
+    expect("text" in output.parts[0] ? output.parts[0].text : "").toContain("Feature workspace");
+    expect("text" in output.parts[0] ? output.parts[0].text : "").toContain("/tmp/feat-auth");
+    expect("text" in output.parts[0] ? output.parts[0].text : "").toContain("tasks.md, plan.md");
+  });
+
+  it("does not add pre-script context for commands without scripts", async () => {
+    const projectRoot = mkdtempSync(path.join(tmpdir(), "sdd-plugin-command-noscript-"));
+    mkdirSync(path.join(projectRoot, ".specify"));
+    mkdirSync(path.join(projectRoot, "specs"));
+    mkdirSync(path.join(projectRoot, ".opencode", "command"), { recursive: true });
+    await Bun.write(
+      path.join(projectRoot, ".opencode", "command", "custom.md"),
+      `---
+description: Custom command
+agent: build
+---
+
+# Content`,
+    );
+
+    const hooks = await sddPlugin(createPluginInput(projectRoot));
+    const output = {
+      parts: [],
+    } as Parameters<NonNullable<PluginHooks["command.execute.before"]>>[1];
+
+    await hooks["command.execute.before"]?.(
+      {
+        command: "custom",
+        sessionID: "session_1",
+        arguments: "",
+      },
+      output,
+    );
+
+    expect(output.parts).toHaveLength(0);
   });
 
   it("does NOT inject the /sdd template for slash commands with arguments", async () => {


### PR DESCRIPTION
## Summary
- move command pre-script execution into OpenCode's real command pipeline via `command.execute.before`
- register bundled command templates with resolvable absolute paths so `/sdd-init` works before repo bootstrap
- add regression coverage for slash-command pre-scripts and bundled-command registration, and bump package version to `0.6.2`

## Changes
- update command discovery to parse top-level `agent` and preserve internal `scripts` metadata without leaking unsupported fields into `config.command`
- stop relying on `chat.message` for slash command pre-script execution and inject structured script output only during command execution
- add tests covering pre-script injection for `/implement` and bundled fallback registration for `/sdd-init`

## Testing
- [x] `cd .opencode && bun test tests/unit/plugin/command-registry.test.ts tests/unit/plugin/index.test.ts tests/unit/workflow/implement-regression.test.ts`
- [x] `cd .opencode && bunx tsc --noEmit`
- [x] `cd .opencode && bun test`