### PR TITLE
fix(plugin): register command templates as prompt content

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helldinhow/sdd-flow-opencode-plugin",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OpenCode Spec-Driven Development workflow plugin and bootstrap kit",
   "homepage": "https://github.com/Heldinhow/sdd-flow#readme",
   "repository": {

--- a/.opencode/src/plugin/command-registry.ts
+++ b/.opencode/src/plugin/command-registry.ts
@@ -116,6 +116,15 @@ function parseYamlFrontmatter(content: string): CommandFrontmatter | null {
   return result;
 }
 
+function extractTemplateContent(content: string): string {
+  const frontmatterMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  if (!frontmatterMatch) {
+    return content;
+  }
+
+  return content.slice(frontmatterMatch[0].length).replace(/^\r?\n/, "");
+}
+
 function discoverCommands(projectRoot: string): Map<string, CommandEntry> {
   const repoLocalCommandsDir = resolveCommandsDir(projectRoot);
   const commands = new Map<string, CommandEntry>();
@@ -138,7 +147,7 @@ function discoverCommands(projectRoot: string): Map<string, CommandEntry> {
 
     const frontmatter = parseYamlFrontmatter(content);
     const entry: CommandEntry = {
-      template: filePath,
+      template: extractTemplateContent(content),
       filePath,
     };
 
@@ -182,5 +191,5 @@ function registerCommands(config: Config, projectRoot: string): void {
   }
 }
 
-export { discoverCommands, parseYamlFrontmatter, registerCommands, resolvePackageRoot };
+export { discoverCommands, extractTemplateContent, parseYamlFrontmatter, registerCommands, resolvePackageRoot };
 export type { CommandEntry, CommandFrontmatter };

--- a/.opencode/tests/unit/plugin/command-registry.test.ts
+++ b/.opencode/tests/unit/plugin/command-registry.test.ts
@@ -3,7 +3,12 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 
-import { discoverCommands, parseYamlFrontmatter, registerCommands } from "../../../src/plugin/command-registry";
+import {
+  discoverCommands,
+  extractTemplateContent,
+  parseYamlFrontmatter,
+  registerCommands,
+} from "../../../src/plugin/command-registry";
 
 describe("command-registry", () => {
   describe("parseYamlFrontmatter", () => {
@@ -93,6 +98,21 @@ description: Simple command
 
       expect(result).not.toBeNull();
       expect(result!.scripts).toBeUndefined();
+    });
+
+    it("extracts template content without frontmatter", () => {
+      const content = `---
+description: Simple command
+agent: build
+---
+
+# Command Body
+
+Run this command.`;
+
+      expect(extractTemplateContent(content)).toBe(`# Command Body
+
+Run this command.`);
     });
   });
 
@@ -187,7 +207,7 @@ handoffs:
       expect(entry!.scripts!.sh).toContain("--require-tasks");
     });
 
-    it("sets template path correctly", () => {
+    it("stores command template content instead of a file path", () => {
       const testRoot = path.join(tmpdir(), "sdd-command-test-" + Date.now());
       rmSync(testRoot, { recursive: true, force: true });
       mkdirSync(path.join(testRoot, ".opencode", "command"), { recursive: true });
@@ -205,12 +225,13 @@ description: SDD command
       const entry = commands.get("sdd");
 
       expect(entry).toBeDefined();
-      expect(entry!.template).toBe(path.join(testRoot, ".opencode", "command", "sdd.md"));
+      expect(entry!.template).toBe("# Content");
+      expect(entry!.template).not.toContain(".opencode/command/sdd.md");
 
       rmSync(testRoot, { recursive: true, force: true });
     });
 
-    it("registers bundled commands with resolvable template paths before repo init", () => {
+    it("registers bundled commands with template content before repo init", () => {
       const testRoot = path.join(tmpdir(), "sdd-bundle-config-" + Date.now());
       rmSync(testRoot, { recursive: true, force: true });
       mkdirSync(testRoot, { recursive: true });
@@ -220,8 +241,8 @@ description: SDD command
 
       expect(config.command).toBeDefined();
       expect(config.command?.["sdd-init"]).toBeDefined();
-      expect(config.command?.["sdd-init"]?.template).toContain("managed-assets");
-      expect(config.command?.["sdd-init"]?.template).toEndWith(path.join(".opencode", "command", "sdd-init.md"));
+      expect(config.command?.["sdd-init"]?.template).toContain("## User Input");
+      expect(config.command?.["sdd-init"]?.template).not.toContain(".opencode/command/sdd-init.md");
 
       rmSync(testRoot, { recursive: true, force: true });
     });


### PR DESCRIPTION
## Summary
- register OpenCode command templates as prompt content instead of filesystem paths
- strip command frontmatter before storing template text so slash commands execute the command body
- add regression coverage and bump the package version to `0.6.3`

## Changes
- add a template-content extractor in the command registry
- keep internal metadata like `scripts` and `agent`, but send only command body text to `config.command[...]`
- add tests proving bundled and repo-local commands no longer surface `.md` file paths to the model

## Testing
- [x] `cd .opencode && bun test tests/unit/plugin/command-registry.test.ts tests/unit/plugin/index.test.ts tests/unit/workflow/implement-regression.test.ts && bunx tsc --noEmit`
- [x] `cd .opencode && bun test`