### PR TITLE
init: add MIT license to repository

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -2,6 +2,7 @@
   "name": "@helldinhow/sdd-flow-opencode-plugin",
   "version": "0.6.4",
   "description": "OpenCode Spec-Driven Development workflow plugin and bootstrap kit",
+  "license": "MIT",
   "homepage": "https://github.com/Heldinhow/sdd-flow#readme",
   "repository": {
     "type": "git",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Heldinhow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -566,3 +566,9 @@ sdd-flow/
 ├── AGENTS.md                 # Repository development guidance
 └── README.md
 ```
+
+---
+
+## License
+
+This project is licensed under the MIT License. See `LICENSE` for the full text.

--- a/specs/mit-license/.branch-name
+++ b/specs/mit-license/.branch-name
@@ -1,0 +1,1 @@
+init-mit-license

--- a/specs/mit-license/data-model.md
+++ b/specs/mit-license/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: MIT License Adoption
+
+## Overview
+
+This feature does not introduce runtime entities or persistence changes. The only affected structures are repository metadata and documentation artifacts.
+
+## Artifacts and Relationships
+
+### `LICENSE`
+
+- Type: root-level text artifact
+- Purpose: canonical legal source for repository licensing
+- Relationship: referenced by `README.md`; semantically matched by `.opencode/package.json`
+
+### `README.md`
+
+- Type: repository documentation artifact
+- Purpose: human-readable discoverability for licensing
+- Relationship: points readers to `LICENSE`
+
+### `.opencode/package.json`
+
+- Type: package metadata artifact
+- Relevant field: `license`
+- Purpose: machine-readable license declaration for tooling and package consumers
+- Relationship: must align with `LICENSE`
+
+## Field-Level Changes
+
+| Artifact | Field / Section | Change |
+|---------|------------------|--------|
+| `LICENSE` | full document | Add standard MIT text |
+| `README.md` | `License` section | Add concise pointer to `LICENSE` |
+| `.opencode/package.json` | `license` | Add `MIT` |
+
+## Integrity Rules
+
+- `LICENSE` is the source of truth for repository licensing.
+- `README.md` must not describe a different license than the root `LICENSE`.
+- `.opencode/package.json` must declare the same license identifier as the repository license.
+
+## API / Contract Impact
+
+- No API endpoints change.
+- No CLI behavior changes.
+- No schema migrations or type updates are required.

--- a/specs/mit-license/plan.md
+++ b/specs/mit-license/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan: MIT License Adoption
+
+## Overview
+
+**Feature**: MIT License Adoption
+**Status**: Draft for Approval
+**Created**: 2026-03-21
+**Approved Input**: `specs/mit-license/spec.md`
+
+This plan introduces standard MIT licensing metadata to the repository without changing runtime behavior. The work is limited to conventional discovery points: root license text, README license documentation, and package manifest metadata.
+
+## Goals
+
+- Publish a canonical MIT license at the repository root.
+- Make license discovery obvious in repository documentation.
+- Ensure package metadata reports `MIT` consistently for tooling.
+
+## Non-Goals
+
+- Adding license headers to source files.
+- Changing runtime code, APIs, or plugin behavior.
+- Introducing alternative licenses, dual licensing, or contributor agreements.
+
+## Technical Context
+
+- Repository type: OpenCode plugin/workflow repository with markdown planning artifacts and a Bun-based package in `.opencode/`.
+- Affected documentation surface: root `README.md`.
+- Affected metadata surface: `.opencode/package.json`.
+- New required governance artifact: root `LICENSE`.
+- Verification style: direct file inspection and manifest consistency checks.
+
+## Constitution Check
+
+- Markdown-only planning flow is preserved; this plan defines only markdown artifacts.
+- The eventual implementation remains documentation/governance-only and avoids application behavior changes.
+- No destructive repository changes are required.
+- The plan maintains traceability to the original request and accepted clarifications.
+
+## Project Structure
+
+### Files to Create
+
+- `LICENSE`
+
+### Files to Modify
+
+- `README.md`
+- `.opencode/package.json`
+
+### Planning Artifacts
+
+- `specs/mit-license/spec.md`
+- `specs/mit-license/plan.md`
+- `specs/mit-license/research.md`
+- `specs/mit-license/data-model.md`
+- `specs/mit-license/quickstart.md`
+
+## Approach
+
+### Architecture
+
+Use conventional open source repository locations so humans and tooling both detect the license with no custom logic. The implementation centers on one source of legal text (`LICENSE`) and two discoverability mirrors: the README section for readers and the package manifest `license` field for ecosystem tooling.
+
+### Alternatives Considered
+
+1. **License file only** - rejected because it leaves README readers and package tooling with weaker discoverability.
+2. **Per-file license headers everywhere** - rejected because it expands scope substantially without being required for standard MIT publication in this repository.
+3. **Custom license text variant** - rejected because standard MIT wording is clearer and better recognized by tooling.
+
+## Implementation Details
+
+### Phase 1: Publish canonical license text
+
+**Duration**: Short
+**Dependencies**: Approved spec
+
+#### Tasks
+
+- [ ] Create a root-level `LICENSE` file using the standard MIT text.
+- [ ] Set the copyright line to `Copyright (c) 2026 Heldinhow`.
+- [ ] Confirm the final text is unmodified beyond year and holder replacement.
+
+### Phase 2: Expose license in repository documentation
+
+**Duration**: Short
+**Dependencies**: Phase 1
+
+#### Tasks
+
+- [ ] Add a concise `License` section to `README.md`.
+- [ ] Link the section to the root `LICENSE` file.
+- [ ] Keep the README change minimal and aligned with the existing documentation tone.
+
+### Phase 3: Align package metadata
+
+**Duration**: Short
+**Dependencies**: Phase 1
+
+#### Tasks
+
+- [ ] Add or update the `license` field in `.opencode/package.json` to `MIT`.
+- [ ] Ensure the manifest value matches the repository license exactly.
+- [ ] Avoid unrelated package metadata changes.
+
+### Phase 4: Verify consistency
+
+**Duration**: Short
+**Dependencies**: Phases 1-3
+
+#### Tasks
+
+- [ ] Re-read `LICENSE`, `README.md`, and `.opencode/package.json` for consistency.
+- [ ] Confirm the README and manifest both point to the same MIT licensing decision.
+- [ ] Confirm no additional legal/governance surfaces were unintentionally changed.
+
+## Data Model Impact
+
+- New artifact: repository-level `LICENSE` text document.
+- Existing metadata updated: `.opencode/package.json` `license` field.
+- No runtime data models, schemas, or APIs are affected.
+
+## Complexity Tracking
+
+| Area | Complexity | Notes |
+|------|------------|-------|
+| Legal text insertion | Low | Standard MIT template with only holder/year substitution |
+| README update | Low | Single small section addition |
+| Package metadata alignment | Low | One-field manifest change |
+| Regression risk | Low | No code-path changes |
+
+## Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Incorrect MIT wording | Medium | Low | Use canonical MIT text and only substitute year/holder |
+| Manifest/documentation mismatch | Medium | Low | Verify `LICENSE`, `README.md`, and `.opencode/package.json` together |
+| Over-scoping into broader legal policy | Low | Medium | Keep implementation constrained to approved spec and explicit out-of-scope items |
+
+## Testing Strategy
+
+- Use direct content verification rather than runtime tests because the change is documentation/metadata-only.
+- Validate that `LICENSE` contains recognizable MIT wording and the approved holder/year.
+- Validate that `README.md` and `.opencode/package.json` both reflect MIT licensing.
+
+## Success Metrics
+
+- `LICENSE` exists at the repository root with standard MIT content.
+- `README.md` contains a discoverable `License` section.
+- `.opencode/package.json` declares `MIT` in its `license` field.
+
+## Open Questions
+
+- None at planning time.

--- a/specs/mit-license/quickstart.md
+++ b/specs/mit-license/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: MIT License Adoption
+
+## Summary of Planned Change
+
+This feature adds standard MIT licensing to the repository through three conventional surfaces:
+
+1. root `LICENSE`
+2. `README.md` `License` section
+3. `.opencode/package.json` `license` field
+
+## Implementation Targets
+
+- `LICENSE`
+- `README.md`
+- `.opencode/package.json`
+
+## Verification Checklist
+
+1. Open `LICENSE` and confirm it contains the standard MIT license text.
+2. Confirm the copyright line is `Copyright (c) 2026 Heldinhow`.
+3. Open `README.md` and confirm it has a short `License` section pointing to `LICENSE`.
+4. Open `.opencode/package.json` and confirm it contains `"license": "MIT"`.
+5. Confirm no unrelated repository files were changed as part of the implementation.
+
+## Expected Outcome
+
+- Repository visitors can discover the license quickly.
+- Package tooling can report the project license correctly.
+- The implementation remains limited to documentation and metadata.
+
+## Breaking Changes
+
+- None.

--- a/specs/mit-license/research.md
+++ b/specs/mit-license/research.md
@@ -1,0 +1,68 @@
+# Research: MIT License Adoption
+
+## Background
+
+The repository currently documents project purpose, installation, and workflow behavior in `README.md`, and it publishes package metadata from `.opencode/package.json`. For open source consumers, the common expectation is that licensing appears in a root `LICENSE` file, is discoverable from the README, and is machine-readable from the package manifest when the project is distributed through package tooling.
+
+## Existing Repository Signals
+
+- `README.md` is the main human-readable entrypoint for repository visitors.
+- `.opencode/package.json` is the current package manifest and does not yet declare a `license` field.
+- No separate legal or contributor-policy files are required for the requested scope.
+
+## Options Considered
+
+### Option 1: Add only `LICENSE`
+
+**Pros**:
+- Minimal change set
+- Satisfies the core legal publication requirement
+
+**Cons**:
+- Weaker discoverability for README readers
+- Package tooling may not surface the license clearly
+
+**Decision**: Rejected in favor of better discoverability.
+
+### Option 2: Add `LICENSE`, README section, and manifest metadata
+
+**Pros**:
+- Matches common open source repository conventions
+- Covers both human readers and tooling consumers
+- Keeps scope small and non-invasive
+
+**Cons**:
+- Touches three surfaces instead of one
+
+**Decision**: Accepted.
+
+### Option 3: Add per-file license headers too
+
+**Pros**:
+- Strong file-level attribution visibility
+
+**Cons**:
+- High churn for little practical benefit here
+- Expands review surface significantly
+
+**Decision**: Rejected as out of scope.
+
+## Decision Rationale
+
+Option 2 best fits the approved request because it makes licensing explicit in the standard places without changing runtime behavior or introducing legal-policy complexity. It also keeps the resulting implementation easy to review and easy for downstream tools to recognize.
+
+## Risks Identified
+
+- Using altered MIT text could create unnecessary ambiguity.
+- Forgetting the package manifest would leave machine-readable metadata incomplete.
+- Over-expanding the change into contributor/legal policy work would delay a simple repository-governance update.
+
+## Final Decision
+
+Proceed with:
+
+1. Root `LICENSE` using canonical MIT text
+2. `README.md` `License` section
+3. `.opencode/package.json` `license: "MIT"`
+
+Approved holder value: `Heldinhow`

--- a/specs/mit-license/spec.md
+++ b/specs/mit-license/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: MIT License Adoption
+
+## Summary
+
+**Feature Name**: MIT License Adoption
+**Type**: Enhancement
+**Status**: Draft for Approval
+**Created**: 2026-03-21
+**Source Request**: "como adicionar uma licença MIT nesse repo open source?"
+**Clarifications**:
+- Documentation scope approved: create `LICENSE`, add a short license section to `README`, and set package metadata to `MIT` when a package manifest exists.
+- Copyright holder: `Heldinhow`
+- Explicitly out of scope: adding source-file license headers.
+
+## Problem Statement
+
+The repository does not clearly publish an open source license for downstream users, contributors, and redistributors. Without an explicit MIT license file and matching repository/package metadata, users cannot easily determine their reuse rights and maintainers leave unnecessary ambiguity around distribution terms.
+
+## User Stories
+
+### Story 1: Discover repository licensing
+
+**As a**: developer evaluating the repository
+**I want**: to see the project license in the repository root and README
+**So that**: I can quickly understand whether I may use, modify, and redistribute the project
+
+**Acceptance Criteria**:
+- [ ] A root-level `LICENSE` file contains the standard MIT license text.
+- [ ] The MIT text includes `Copyright (c) 2026 Heldinhow`.
+- [ ] `README.md` includes a short `License` section that points readers to the root `LICENSE` file.
+
+### Story 2: Discover package licensing
+
+**As a**: package consumer or tooling system
+**I want**: package metadata to declare the MIT license
+**So that**: ecosystem tooling can detect the license consistently
+
+**Acceptance Criteria**:
+- [ ] If a package manifest exists, it declares the license as `MIT`.
+- [ ] The package metadata change aligns with the license published in the repository root.
+
+## Requirements
+
+### Functional Requirements
+
+- [FR-1]: The repository must include a root-level `LICENSE` file with the standard MIT license text.
+- [FR-2]: The MIT license text must name `Heldinhow` as the copyright holder.
+- [FR-3]: `README.md` must expose a concise `License` section that references the MIT license.
+- [FR-4]: Any existing package manifest used by the repository must declare `MIT` as its license value.
+
+### Non-Functional Requirements
+
+- [NFR-1]: The change must remain documentation/governance-only and must not introduce source-code behavior changes.
+- [NFR-2]: The license text must be standard and recognizable by common open source tooling.
+- [NFR-3]: The update must preserve discoverability by keeping licensing information in conventional locations.
+
+## Design
+
+### UI/UX
+
+No application UI changes are required. The only user-facing documentation change is a short repository-level `License` section in `README.md`.
+
+### API Design
+
+No API changes are required.
+
+### Data Model
+
+No runtime data model changes are required. The relevant metadata surface is the package manifest `license` field, if present.
+
+## Dependencies
+
+- Existing repository documentation structure (`README.md`)
+- Existing package manifest, if present (`.opencode/package.json`)
+
+## Constraints
+
+- Use the canonical MIT license text without custom terms.
+- Do not add per-file license headers in this scope.
+- Do not change project ownership history beyond the stated MIT copyright notice.
+
+## Out of Scope
+
+- Replacing MIT with another open source license
+- Adding copyright/license headers to source files
+- Broader legal policy, CLA, or contributor agreement work
+
+## Success Criteria
+
+- The repository root clearly publishes MIT licensing through `LICENSE`.
+- Repository readers can discover licensing from `README.md` without searching.
+- Package/tooling consumers can detect `MIT` from the package manifest when present.

--- a/specs/mit-license/tasks.md
+++ b/specs/mit-license/tasks.md
@@ -1,0 +1,64 @@
+# Task Breakdown: MIT License Adoption
+
+## Overview
+
+**Feature**: MIT License Adoption
+**Total Tasks**: 5
+**Estimated Duration**: Less than half a day
+
+## Phase 1: Canonical License Publication
+
+- [X] **T001**: Create the root `LICENSE` file with the canonical MIT text and the approved holder/year.
+  - **Type**: documentation
+  - **Priority**: high
+  - **Dependencies**: none
+  - **Verification**: Confirm `LICENSE` exists and includes standard MIT wording plus `Copyright (c) 2026 Heldinhow`.
+
+## Phase 2: Repository Discoverability
+
+- [X] **T002**: Add a concise `License` section to `README.md` that points readers to the root `LICENSE` file.
+  - **Type**: documentation
+  - **Priority**: high
+  - **Dependencies**: T001
+  - **Verification**: Confirm `README.md` includes a short `License` section referencing `LICENSE`.
+
+## Phase 3: Package Metadata Alignment
+
+- [X] **T003**: Add or update the `license` field in `.opencode/package.json` to `MIT`.
+  - **Type**: config
+  - **Priority**: high
+  - **Dependencies**: T001
+  - **Verification**: Confirm `.opencode/package.json` contains `"license": "MIT"` and no unrelated metadata changed.
+
+## Phase 4: Consistency Verification
+
+- [X] **T004 [P]**: Review `LICENSE`, `README.md`, and `.opencode/package.json` together for consistent MIT wording and scope.
+  - **Type**: testing
+  - **Priority**: medium
+  - **Dependencies**: T002, T003
+  - **Verification**: Confirm all three surfaces reference the same MIT licensing decision and approved holder/year.
+
+## Phase 5: Final Documentation Checkpoint
+
+- [X] **T005**: Perform a final change review to ensure the implementation stayed within the approved spec and plan.
+  - **Type**: documentation
+  - **Priority**: medium
+  - **Dependencies**: T004
+  - **Verification**: Confirm only `LICENSE`, `README.md`, and `.opencode/package.json` require implementation changes for this feature.
+
+## Execution Order
+
+```text
+T001 → T002 + T003 → T004 → T005
+```
+
+## Checkpoints
+
+- **Checkpoint 1**: `T001` complete before any discoverability or metadata changes.
+- **Checkpoint 2**: `T002` and `T003` complete before consistency review.
+- **Checkpoint 3**: `T004` and `T005` complete before implementation handoff.
+
+## Notes
+
+- `T002` and `T003` may proceed in parallel after `T001` because both depend only on the canonical license decision.
+- No source-code behavior changes, per-file headers, or broader legal-policy work are included in this task set.


### PR DESCRIPTION
## Summary
- Adiciona licenca MIT ao repositorio com copyright de Heldinhow
- Cria arquivo `LICENSE` na raiz com texto padrao MIT
- Adiciona secao License ao `README.md`
- Define `"license": "MIT"` no manifesto do pacote `.opencode/package.json`

## Changes
- `LICENSE` - novo arquivo com texto MIT padrao
- `README.md` - secao License apontando para LICENSE
- `.opencode/package.json` - campo license definido como MIT
- `specs/mit-license/` - workspace SDD com artefatos de planejamento

## Test Plan
- [x] Typecheck passa: `bunx tsc --noEmit`
- [x] Unit tests passam: 106 pass, 0 fail
- [x] Verificacao manual dos 3 pontos de superficie da licenca concluida