### PR TITLE
fix(agent): provide feedback when SDD backend template is missing

### DIFF
--- a/.opencode/src/plugin/spec-driven-agent.ts
+++ b/.opencode/src/plugin/spec-driven-agent.ts
@@ -116,6 +116,30 @@ function injectSddBackendTemplate(projectRoot: string, output: ChatMessageOutput
 
   const template = loadSddTemplate(projectRoot);
   if (!template) {
+    const templatePath = path.join(projectRoot, ...SDD_COMMAND_PATH);
+    const errorMessage = [
+      "⚠️ **SDD Backend Template Missing**",
+      "",
+      `The SDD backend template is required but not found at: ${templatePath}`,
+      "",
+      "The Spec Driven agent will operate without critical SDD workflow orchestration instructions.",
+      "",
+      "**To fix this:**",
+      "1. Run \`/sdd-init\` in the build agent to initialize the repository",
+      "2. This will create the required `.opencode/command/sdd.md` template",
+      "3. Then return to Spec Driven for proper workflow guidance",
+    ].join("\n");
+
+    console.warn(`[SDD Plugin] Template not found at ${templatePath}`);
+
+    output.parts.unshift({
+      id: `prt-${output.message.id}-sdd-template-missing`,
+      sessionID: output.message.sessionID,
+      messageID: output.message.id,
+      type: "text",
+      synthetic: true,
+      text: errorMessage,
+    });
     return;
   }
 


### PR DESCRIPTION
Fixes #20

When the SDD command template at .opencode/command/sdd.md is not found, the agent would operate silently without critical workflow instructions.

This fix:
- Logs a warning to console when template is missing
- Injects an error message into the output to alert the user
- Provides guidance on how to resolve (run /sdd-init)
- Ensures visibility of the missing template issue

## Testing
- All 116 tests pass
- Error message will be visible in chat output when template is missing