### PR TITLE
fix(workspace): replace mtime with git-based detection

### DIFF
--- a/.opencode/src/workflow/detect-active-workspace.ts
+++ b/.opencode/src/workflow/detect-active-workspace.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from "node:fs";
+import { readdirSync, existsSync } from "node:fs";
 import { execSync } from "node:child_process";
 import path from "node:path";
 
@@ -14,31 +14,82 @@ function getCurrentBranch(): string | null {
   }
 }
 
+function hasUncommittedChanges(workspacePath: string): boolean {
+  try {
+    const output = execSync("git status --porcelain", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+      cwd: workspacePath,
+    });
+    return output.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function hasRecentEdits(workspacePath: string): boolean {
+  try {
+    const output = execSync(
+      "git log --oneline -1 -- spec.md plan.md",
+      {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "ignore"],
+        cwd: workspacePath,
+      },
+    );
+    return output.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function isGitAvailable(repoRoot: string): boolean {
+  try {
+    execSync("git rev-parse --git-dir", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+      cwd: repoRoot,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function detectActiveWorkspace(repoRoot: string): string | null {
   const specsRoot = path.join(repoRoot, "specs");
 
   try {
-    const entries = readdirSync(specsRoot)
-      .filter((entry) => statSync(path.join(specsRoot, entry)).isDirectory());
+    const entries = readdirSync(specsRoot).filter((entry) =>
+      existsSync(path.join(specsRoot, entry, "spec.md")),
+    );
 
     if (entries.length === 0) {
       return null;
     }
 
-    // Try to match current git branch to a workspace directory name
     const currentBranch = getCurrentBranch();
     if (currentBranch && currentBranch !== "HEAD" && entries.includes(currentBranch)) {
       return currentBranch;
     }
 
-    // Fallback: return the most recently modified workspace
-    const sorted = entries.sort((left, right) => {
-      const leftPath = path.join(specsRoot, left);
-      const rightPath = path.join(specsRoot, right);
-      return statSync(leftPath).mtimeMs - statSync(rightPath).mtimeMs;
-    });
+    if (isGitAvailable(repoRoot)) {
+      const withUncommitted = entries.filter((entry) =>
+        hasUncommittedChanges(path.join(specsRoot, entry)),
+      );
+      if (withUncommitted.length === 1) {
+        return withUncommitted[0];
+      }
 
-    return sorted.at(-1) ?? null;
+      const withRecentEdits = entries.filter((entry) =>
+        hasRecentEdits(path.join(specsRoot, entry)),
+      );
+      if (withRecentEdits.length === 1) {
+        return withRecentEdits[0];
+      }
+    }
+
+    return entries[0] ?? null;
   } catch {
     return null;
   }

--- a/.opencode/tests/unit/workflow/detect-active-workspace.test.ts
+++ b/.opencode/tests/unit/workflow/detect-active-workspace.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { detectActiveWorkspace } from "../../../src/workflow/detect-active-workspace";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+describe("detectActiveWorkspace", () => {
+  let tempRoot: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), "sdd-workspace-test-"));
+    mkdirSync(path.join(tempRoot, "specs"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("returns null when specs directory does not exist", () => {
+    rmSync(path.join(tempRoot, "specs"), { recursive: true });
+    expect(detectActiveWorkspace(tempRoot)).toBeNull();
+  });
+
+  it("returns null when specs directory is empty", () => {
+    expect(detectActiveWorkspace(tempRoot)).toBeNull();
+  });
+
+  it("returns workspace when spec.md exists in directory", () => {
+    const workspaceDir = path.join(tempRoot, "specs", "my-workspace");
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(path.join(workspaceDir, "spec.md"), "# Test");
+    expect(detectActiveWorkspace(tempRoot)).toBe("my-workspace");
+  });
+
+  it("returns null when no workspace has spec.md", () => {
+    const workspaceDir = path.join(tempRoot, "specs", "empty-workspace");
+    mkdirSync(workspaceDir, { recursive: true });
+    expect(detectActiveWorkspace(tempRoot)).toBeNull();
+  });
+
+  it("returns first workspace when multiple exist", () => {
+    mkdirSync(path.join(tempRoot, "specs", "workspace-a"), { recursive: true });
+    mkdirSync(path.join(tempRoot, "specs", "workspace-b"), { recursive: true });
+    writeFileSync(path.join(tempRoot, "specs", "workspace-a", "spec.md"), "# A");
+    writeFileSync(path.join(tempRoot, "specs", "workspace-b", "spec.md"), "# B");
+    expect(detectActiveWorkspace(tempRoot)).toBe("workspace-a");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #16 - detect-active-workspace.ts uses unreliable mtime

### Changes:
- Git branch match as primary indicator
- Uncommitted changes check via `git status --porcelain`
- Recent edits via `git log` on spec.md/plan.md
- File existence fallback (not mtime) when git unavailable
- New unit tests