### PR TITLE
fix: $ARGUMENTS regex could match $ARGUMENTS_MORE as substring

### DIFF
--- a/.opencode/src/plugin/spec-driven-agent.ts
+++ b/.opencode/src/plugin/spec-driven-agent.ts
@@ -149,7 +149,7 @@ function injectSddBackendTemplate(projectRoot: string, output: ChatMessageOutput
     messageID: output.message.id,
     type: "text",
     synthetic: true,
-    text: template.replaceAll("$ARGUMENTS", userText),
+    text: template.replaceAll(/\$ARGUMENTS\b/g, userText),
   });
 }
 


### PR DESCRIPTION
Fixes #57

Use /\$ARGUMENTS\\b/g instead of replaceAll("$ARGUMENTS", ...) to prevent matching $ARGUMENTS_MORE or other longer variable names that contain $ARGUMENTS as a substring.