### PR TITLE
fix: CRLF vs LF causes false positives in merge-managed-assets

### DIFF
--- a/.opencode/src/init/merge-managed-assets.ts
+++ b/.opencode/src/init/merge-managed-assets.ts
@@ -34,8 +34,8 @@ function createMergePlan(targetRoot: string, managedAssets: ManagedAsset[]): Mer
       };
     }
 
-    const sourceContents = readFileSync(asset.sourcePath, "utf8");
-    const targetContents = readFileSync(targetPath, "utf8");
+    const sourceContents = readFileSync(asset.sourcePath, "utf8").replace(/\r\n/g, "\n");
+    const targetContents = readFileSync(targetPath, "utf8").replace(/\r\n/g, "\n");
     return {
       action: sourceContents === targetContents ? MERGE_ACTION.KEEP : MERGE_ACTION.REVIEW,
       relativePath: asset.relativePath,


### PR DESCRIPTION
Fixes #63

Normalize CRLF to LF in both source and target file contents before comparing them, preventing false positives where identical content with different line endings would be flagged for review.